### PR TITLE
127 translating non member and anonymous roles when importing defaults

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -912,6 +912,8 @@ bg:
   default_role_manager: Мениджър
   default_role_developer: Разработчик
   default_role_reporter: Публикуващ
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Грешка
   default_tracker_feature: Функционалност
   default_tracker_support: Поддръжка

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -795,6 +795,8 @@ bs:
   default_role_manager: Menadžer
   default_role_developer: Programer
   default_role_reporter: Reporter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Greška
   default_tracker_feature: Nova funkcija
   default_tracker_support: Podrška

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -895,6 +895,8 @@ ca:
   default_role_manager: Gestor
   default_role_developer: Desenvolupador
   default_role_reporter: Informador
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Error
   default_tracker_feature: Característica
   default_tracker_support: Suport

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -692,6 +692,8 @@ cs:
   default_role_manager: Manažer
   default_role_developer: Vývojář
   default_role_reporter: Reportér
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Chyba
   default_tracker_feature: Požadavek
   default_tracker_support: Podpora

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -690,6 +690,8 @@ da:
   default_role_manager: Leder
   default_role_developer: Udvikler
   default_role_reporter: Rapportør
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   default_tracker_feature: Feature
   default_tracker_support: Support

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -913,6 +913,8 @@ de:
   default_role_manager: Manager
   default_role_developer: Entwickler
   default_role_reporter: Reporter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Fehler
   default_tracker_feature: Feature
   default_tracker_support: Unterstützung

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -810,6 +810,8 @@ el:
   default_role_manager: Manager
   default_role_developer: Developer
   default_role_reporter: Reporter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Σφάλματα
   default_tracker_feature: Λειτουργίες
   default_tracker_support: Υποστήριξη

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -877,6 +877,8 @@ en-GB:
   default_role_manager: Manager
   default_role_developer: Developer
   default_role_reporter: Reporter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   default_tracker_feature: Feature
   default_tracker_support: Support

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,6 +912,8 @@ en:
   default_role_manager: Manager
   default_role_developer: Developer
   default_role_reporter: Reporter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   default_tracker_feature: Feature
   default_tracker_support: Support

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -233,6 +233,8 @@ es:
   default_role_developer: Desarrollador
   default_role_manager: Jefe de proyecto
   default_role_reporter: Informador
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Errores
   default_tracker_feature: Tareas
   default_tracker_support: Soporte

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -872,6 +872,8 @@ eu:
   default_role_manager: Kudeatzailea
   default_role_developer: Garatzailea
   default_role_reporter: Berriemailea
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Errorea
   default_tracker_feature: Eginbidea
   default_tracker_support: Laguntza

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -659,6 +659,8 @@ fi:
   default_role_manager: Päälikkö
   default_role_developer: Kehittäjä
   default_role_reporter: Tarkastelija
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Ohjelmointivirhe
   default_tracker_feature: Ominaisuus
   default_tracker_support: Tuki

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -893,6 +893,8 @@ fr:
   default_role_manager: "Manager "
   default_role_developer: "Développeur "
   default_role_reporter: "Rapporteur "
+  default_role_non_member: "Non membre "
+  default_role_anonymous: "Anonyme "
   default_tracker_bug: Anomalie
   default_tracker_feature: Evolution
   default_tracker_support: Assistance

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -210,6 +210,8 @@ gl:
   default_role_developer: Desenvolvedor
   default_role_manager: Xefe de proxecto
   default_role_reporter: Informador
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Erros
   default_tracker_feature: Tarefas
   default_tracker_support: Soporte

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -906,6 +906,8 @@ he:
   default_role_manager: מנהל
   default_role_developer: מפתח
   default_role_reporter: מדווח
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: תקלה
   default_tracker_feature: יכולת
   default_tracker_support: תמיכה

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -865,6 +865,8 @@ hr:
   default_role_manager: Upravitelj
   default_role_developer: Razvojni inženjer
   default_role_reporter: Korisnik
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Pogreška
   default_tracker_feature: Funkcionalnost
   default_tracker_support: Podrška

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -715,6 +715,8 @@
   default_role_manager: Vezető
   default_role_developer: Fejlesztő
   default_role_reporter: Bejelentő
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Hiba
   default_tracker_feature: Fejlesztés
   default_tracker_support: Support

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -845,6 +845,8 @@ id:
   default_role_manager: Manager
   default_role_developer: Pengembang
   default_role_reporter: Pelapor
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   default_tracker_feature: Fitur
   default_tracker_support: Dukungan

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -593,6 +593,8 @@ it:
   default_role_manager: Gestore
   default_role_developer: Sviluppatore
   default_role_reporter: Segnalatore
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Segnalazione
   default_tracker_feature: Funzione
   default_tracker_support: Supporto

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -934,6 +934,8 @@ ja:
   default_role_manager: 管理者
   default_role_developer: 開発者
   default_role_reporter: 報告者
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: バグ
   default_tracker_feature: 機能
   default_tracker_support: サポート

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -855,6 +855,8 @@ ko:
   default_role_manager: 관리자
   default_role_developer: 개발자
   default_role_reporter: 보고자
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: 결함
   default_tracker_feature: 새기능
   default_tracker_support: 지원

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -897,6 +897,8 @@ lt:
   default_role_manager: Vadovas
   default_role_developer: Projektuotojas
   default_role_reporter: Pranešėjas
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Klaida
   default_tracker_feature: Ypatybė
   default_tracker_support: Palaikymas

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -867,6 +867,8 @@ lv:
   default_role_manager: Menedžeris
   default_role_developer: Izstrādātājs
   default_role_reporter: Ziņotājs
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Kļūda
   default_tracker_feature: Iezīme
   default_tracker_support: Atbalsts

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -892,6 +892,8 @@ mk:
   default_role_manager: Менаџер
   default_role_developer: Developer
   default_role_reporter: Reporter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Грешка
   default_tracker_feature: Функционалност
   default_tracker_support: Поддршка

--- a/config/locales/mn.yml
+++ b/config/locales/mn.yml
@@ -872,6 +872,8 @@ mn:
   default_role_manager: Менежер
   default_role_developer: Хөгжүүлэгч
   default_role_reporter: Мэдэгдэгч
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Алдаа
   default_tracker_feature: Онцлог
   default_tracker_support: Тусламж

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -180,6 +180,8 @@ nl:
   default_role_developer: Ontwikkelaar
   default_role_manager: Manager
   default_role_reporter: Rapporteur
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   default_tracker_feature: Feature
   default_tracker_support: Support

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -688,6 +688,8 @@
   default_role_manager: Leder
   default_role_developer: Utvikler
   default_role_reporter: Rapportør
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Feil
   default_tracker_feature: Funksjon
   default_tracker_support: Support

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -197,6 +197,8 @@ pl:
   default_role_developer: Programista
   default_role_manager: Kierownik
   default_role_reporter: Wprowadzajacy
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Błąd
   default_tracker_feature: Zadanie
   default_tracker_support: Wsparcie

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -733,6 +733,8 @@ pt-BR:
   default_role_manager: Gerente
   default_role_developer: Desenvolvedor
   default_role_reporter: Informante
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Defeito
   default_tracker_feature: Funcionalidade
   default_tracker_support: Suporte

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -720,6 +720,8 @@ pt:
   default_role_manager: Gestor
   default_role_developer: Programador
   default_role_reporter: Repórter
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   default_tracker_feature: Funcionalidade
   default_tracker_support: Suporte

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -782,6 +782,8 @@ ro:
   default_role_manager: Manager
   default_role_developer: Dezvoltator
   default_role_reporter: Creator de rapoarte
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Defect
   default_tracker_feature: Funcție
   default_tracker_support: Suport

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -271,6 +271,8 @@ ru:
   default_role_developer: Разработчик
   default_role_manager: Менеджер
   default_role_reporter: Генератор отчетов
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Ошибка
   default_tracker_feature: Изменение
   default_tracker_support: Поддержка

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -686,6 +686,8 @@ sk:
   default_role_manager: Manažér
   default_role_developer: Vývojár
   default_role_reporter: Reportér
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Chyba
   default_tracker_feature: Rozšírenie
   default_tracker_support: Podpora

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -768,6 +768,8 @@ sl:
   default_role_manager: Upravnik
   default_role_developer: Razvijalec
   default_role_reporter: Poročevalec
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Hrošč
   default_tracker_feature: Funkcija
   default_tracker_support: Podpora

--- a/config/locales/sr-YU.yml
+++ b/config/locales/sr-YU.yml
@@ -889,6 +889,8 @@ sr-YU:
   default_role_manager: Menadžer
   default_role_developer: Programer
   default_role_reporter: Izveštač
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Greška
   default_tracker_feature: Funkcionalnost
   default_tracker_support: Podrška

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -889,6 +889,8 @@ sr:
   default_role_manager: Менаџер
   default_role_developer: Програмер
   default_role_reporter: Извештач
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Грешка
   default_tracker_feature: Функционалност
   default_tracker_support: Подршка

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -954,6 +954,8 @@ sv:
   default_role_manager: Projektledare
   default_role_developer: Utvecklare
   default_role_reporter: Rapportör
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bugg
   default_tracker_feature: Funktionalitet
   default_tracker_support: Support

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -692,6 +692,8 @@ th:
   default_role_manager: ผู้จัดการ
   default_role_developer: ผู้พัฒนา
   default_role_reporter: ผู้รายงาน
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: บั๊ก
   default_tracker_feature: ลักษณะเด่น
   default_tracker_support: สนับสนุน

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -713,6 +713,8 @@ tr:
   default_role_manager: Yönetici
   default_role_developer: Geliştirici
   default_role_reporter: Raporlayıcı
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Hata
   default_tracker_feature: ÖZellik
   default_tracker_support: Destek

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -661,6 +661,8 @@ uk:
   label_file_added: File added
   label_more: More
   field_default_value: Default value
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Bug
   label_scm: SCM
   label_general: General

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -765,6 +765,8 @@ vi:
   default_role_manager: Điều hành
   default_role_developer: Phát triển
   default_role_reporter: Báo cáo
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: Lỗi
   default_tracker_feature: Tính năng
   default_tracker_support: Hỗ trợ

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -994,6 +994,8 @@
   default_role_manager: 管理人員
   default_role_developer: 開發人員
   default_role_reporter: 報告人員
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: 臭蟲
   default_tracker_feature: 功能
   default_tracker_support: 支援

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -882,6 +882,8 @@ zh:
   default_role_manager: 管理人员
   default_role_developer: 开发人员
   default_role_reporter: 报告人员
+  default_role_non_member: Non member
+  default_role_anonymous: Anonymous
   default_tracker_bug: 错误
   default_tracker_feature: 功能
   default_tracker_support: 支持

--- a/lib/redmine/default_data/loader.rb
+++ b/lib/redmine/default_data/loader.rb
@@ -94,7 +94,8 @@ module Redmine
                                                     :browse_repository,
                                                     :view_changesets]
                         
-            Role.non_member.update_attribute :permissions, [:view_issues,
+            Role.non_member.update_attributes :name => l(:default_role_non_member),
+                                              :permissions => [:view_issues,
                                                             :add_issues,
                                                             :add_issue_notes,
                                                             :save_queries,
@@ -110,7 +111,8 @@ module Redmine
                                                             :browse_repository,
                                                             :view_changesets]
           
-            Role.anonymous.update_attribute :permissions, [:view_issues,
+            Role.anonymous.update_attributes :name => l(:default_role_anonymous),
+                                             :permissions => [:view_issues,
                                                            :view_gantt,
                                                            :view_calendar,
                                                            :view_time_entries,


### PR DESCRIPTION
Hi there,

Here is a commit for [issue 127: Anonymous and Non member roles are not translated](https://www.chiliproject.org/issues/127)

It sets the Non member and Anonymous translations when importing default data.

Cheers :)
