### PR TITLE
Bug #251 make chili work with rubygems 1.6

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -158,5 +158,8 @@ module Rails
   end
 end
 
+# working around deprecation in RubyGems 1.6
+require 'thread'
+
 # All that for this:
 Rails.boot!


### PR DESCRIPTION
adds required require 'thread'
