### PR TITLE
Now users can see what branches changesets belongs to

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -23,6 +23,8 @@ class Changeset < ActiveRecord::Base
   has_many :changes, :dependent => :delete_all
   has_and_belongs_to_many :issues
 
+  serialize :branches
+
   acts_as_event :title => Proc.new {|o| "#{l(:label_revision)} #{o.format_identifier}" + (o.short_comments.blank? ? '' : (': ' + o.short_comments))},
                 :description => :long_comments,
                 :datetime => :committed_on,

--- a/app/views/issues/_changesets.rhtml
+++ b/app/views/issues/_changesets.rhtml
@@ -1,8 +1,16 @@
 <% changesets.each do |changeset| %>
     <div class="changeset <%= cycle('odd', 'even') %>">
     <p><%= link_to_revision(changeset, changeset.project,
-                            :text => "#{l(:label_revision)} #{changeset.format_identifier}") %><br />
-        <span class="author"><%= authoring(changeset.committed_on, changeset.author) %></span></p>
+                            :text => "#{l(:label_revision)} #{changeset.format_identifier}") %>
+        <% if changeset.branches && !changeset.branches.empty? %>
+          [
+          <% changeset.branches.each do |branch| %>
+            <%= link_to branch, :controller => 'repositories', :id => changeset.project, :action => 'show', :branch => branch %>
+          <% end %>
+          ]
+      <% end %>
+      <br />
+      <span class="author"><%= authoring(changeset.committed_on, changeset.author) %></span></p>
     <div class="changeset-changes">
         <%= textilizable(changeset, :comments) %>
     </div>

--- a/db/migrate/20110307211730_add_branches_to_changesets.rb
+++ b/db/migrate/20110307211730_add_branches_to_changesets.rb
@@ -1,0 +1,9 @@
+class AddBranchesToChangesets < ActiveRecord::Migration
+  def self.up
+    add_column :changesets, :branches, :string
+  end
+
+  def self.down
+    remove_column :changesets, :branches
+  end
+end

--- a/lib/redmine/scm/adapters/abstract_adapter.rb
+++ b/lib/redmine/scm/adapters/abstract_adapter.rb
@@ -271,7 +271,7 @@ module Redmine
       end
       
       class Revision
-        attr_accessor :scmid, :name, :author, :time, :message, :paths, :revision, :branch
+        attr_accessor :scmid, :name, :author, :time, :message, :paths, :revision, :branches
         attr_writer :identifier
 
         def initialize(attributes={})
@@ -283,7 +283,7 @@ module Redmine
           self.message = attributes[:message] || ""
           self.paths = attributes[:paths]
           self.revision = attributes[:revision]
-          self.branch = attributes[:branch]
+          self.branches = attributes[:branches]
         end
 
         # Returns the identifier of this revision; see also Changeset model
@@ -305,6 +305,8 @@ module Redmine
               :committer => author, 
               :committed_on => time,
               :comments => message)
+
+            changeset.branches = branches
             
             if changeset.save
               paths.each do |file|


### PR DESCRIPTION
http://twitpic.com/47k9gk

This patch will help me a lot to understand, what commits belongs to what branches. Now it works only for git, but it is quite easy to make it work for others DCVS (bazaar, hg and others)
