### PR TITLE
confusing document overview fixed

### DIFF
--- a/app/views/documents/_document.rhtml
+++ b/app/views/documents/_document.rhtml
@@ -2,5 +2,5 @@
 <p><em><%= format_time(document.updated_on) %></em></p>
 
 <div class="wiki">
-	<%= textilizable(truncate_lines(document.description)) %>
+	<%= textilizable(truncate_lines(document.description)).gsub(/<h[1-5]([ a-zA-Z0-9="-]+)?>/,"<b>").gsub(/<\/h[1-5]+>/,"</b>") %>
 </div>


### PR DESCRIPTION
when a document contains a heading on top, this heading's format and horizontal line will disturb the reader while going through the document overview. Parsing these headings to a bold tag leads to a better overview and enables the user to differentiate between the documents...

headings in the document-overview are now replaced by bold tags, so the horizontal seperators divide the documents and no document heading will disturb the view any longer
