### PR TITLE
#299 - Plugin API to add plugin to project settings menu

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -221,6 +221,15 @@ module ApplicationHelper
     end
   end
   
+  # Renders tabs (using a MenuManager) and their content
+  def render_menu_tabs(tabs)
+    if tabs.any?
+      render :partial => 'common/menu_tabs', :locals => {:tabs => tabs}
+    else
+      content_tag 'p', l(:label_no_data), :class => "nodata"
+    end
+  end
+  
   # Renders the project quick-jump box
   def render_project_jump_box
     # Retrieve them now to avoid a COUNT query

--- a/app/views/common/_menu_tabs.rhtml
+++ b/app/views/common/_menu_tabs.rhtml
@@ -1,0 +1,28 @@
+<% selected_tab = params[:tab] ? params[:tab].to_s : tabs.first.name.to_s %>
+
+<div class="tabs">
+  <ul>
+  <% tabs.each do |tab| -%>
+    <li><%= link_to tab.caption, { :tab => tab.name },
+                                    :id => "tab-#{tab.name}",
+                                    :class => (tab.name.to_s != selected_tab ? nil : 'selected'),
+                                    :onclick => "showTab('#{tab.name}'); this.blur(); return false;" %></li>
+  <% end -%>
+  </ul>
+  <div class="tabs-buttons" style="display:none;">
+  	<button class="tab-left" onclick="moveTabLeft(this);"></button>
+  	<button class="tab-right" onclick="moveTabRight(this);"></button>
+  </div>
+</div>
+
+<script>
+	Event.observe(window, 'load', function() { displayTabsButtons(); });
+	Event.observe(window, 'resize', function() { displayTabsButtons(); }); 
+</script>
+
+<% tabs.each do |tab| -%>
+  <%= content_tag('div', render(:partial => tab.html_options[:partial], :locals => {:tab => tab} ), 
+                       :id => "tab-content-#{tab.name}",
+                       :style => (tab.name.to_s != selected_tab ? 'display:none' : nil),
+                       :class => 'tab-content') %>
+<% end -%>

--- a/app/views/projects/settings.rhtml
+++ b/app/views/projects/settings.rhtml
@@ -1,5 +1,5 @@
 <h2><%=l(:label_settings)%></h2>
 
-<%= render_tabs project_settings_tabs %>
+<%= render_menu_tabs menu_items_for(:project_settings_menu) %>
 
 <% html_title(l(:label_settings)) -%>

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -205,6 +205,18 @@ Redmine::MenuManager.map :project_menu do |menu|
   menu.push :settings, { :controller => 'projects', :action => 'settings' }, :last => true
 end
 
+Redmine::MenuManager.map :project_settings_menu do |menu|
+  menu.push :info, {:action => :edit_project}, :html => {:partial => 'projects/edit'}, :caption => :label_information_plural
+  menu.push :modules, {:action => :select_project_modules}, :html => {:partial => 'projects/settings/modules'}, :caption => :label_module_plural
+  menu.push :members, {:action => :manage_members}, :html => {:partial => 'projects/settings/members'}, :caption => :label_member_plural
+  menu.push :versions, {:action => :manange_versions}, :html => {:partial => 'projects/settings/versions'}, :caption => :label_version_plural
+  menu.push :categories, {:action => :manage_categories}, :html => {:partial => 'projects/settings/issue_categories'}, :caption => :label_issue_status_plural
+  menu.push :wiki, {:action => :manage_wiki}, :html => {:partial => 'projects/settings/wiki'}, :caption => :label_wiki
+  menu.push :repository, {:action => :manage_repository}, :html => {:partial => 'projects/settings/repository'}, :caption => :label_repository
+  menu.push :boards, {:action => :manage_boards}, :html => {:partial => 'projects/settings/boards'}, :caption => :label_board_plural
+  menu.push :activities, {:action => :manage_project_activities}, :html => {:partial => 'projects/settings/activities'}, :caption => :enumeration_activities
+end
+
 Redmine::Activity.map do |activity|
   activity.register :issues, :class_name => %w(Issue Journal)
   activity.register :changesets

--- a/lib/redmine.rb
+++ b/lib/redmine.rb
@@ -210,7 +210,7 @@ Redmine::MenuManager.map :project_settings_menu do |menu|
   menu.push :modules, {:action => :select_project_modules}, :html => {:partial => 'projects/settings/modules'}, :caption => :label_module_plural
   menu.push :members, {:action => :manage_members}, :html => {:partial => 'projects/settings/members'}, :caption => :label_member_plural
   menu.push :versions, {:action => :manange_versions}, :html => {:partial => 'projects/settings/versions'}, :caption => :label_version_plural
-  menu.push :categories, {:action => :manage_categories}, :html => {:partial => 'projects/settings/issue_categories'}, :caption => :label_issue_status_plural
+  menu.push :categories, {:action => :manage_categories}, :html => {:partial => 'projects/settings/issue_categories'}, :caption => :label_issue_category_plural
   menu.push :wiki, {:action => :manage_wiki}, :html => {:partial => 'projects/settings/wiki'}, :caption => :label_wiki
   menu.push :repository, {:action => :manage_repository}, :html => {:partial => 'projects/settings/repository'}, :caption => :label_repository
   menu.push :boards, {:action => :manage_boards}, :html => {:partial => 'projects/settings/boards'}, :caption => :label_board_plural

--- a/test/unit/lib/redmine_test.rb
+++ b/test/unit/lib/redmine_test.rb
@@ -20,7 +20,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 module RedmineMenuTestHelper
   # Assertions
   def assert_number_of_items_in_menu(menu_name, count)
-    assert Redmine::MenuManager.items(menu_name).size >= count, "Menu has less than #{count} items"
+    assert Redmine::MenuManager.items(menu_name).size >= count, "Menu expected to have at least #{count} items. It had #{Redmine::MenuManager.items(menu_name).size}"
   end
 
   def assert_menu_contains_item_named(menu_name, item_name)
@@ -82,5 +82,18 @@ class RedmineTest < ActiveSupport::TestCase
   def test_new_issue_should_have_root_as_a_parent
     new_issue = get_menu_item(:project_menu, :new_issue)
     assert_equal :root, new_issue.parent.name
+  end
+  
+  def test_project_settings_menu
+    assert_number_of_items_in_menu :project_settings_menu, 10
+    assert_menu_contains_item_named :project_settings_menu, :info
+    assert_menu_contains_item_named :project_settings_menu, :modules
+    assert_menu_contains_item_named :project_settings_menu, :members
+    assert_menu_contains_item_named :project_settings_menu, :versions
+    assert_menu_contains_item_named :project_settings_menu, :categories
+    assert_menu_contains_item_named :project_settings_menu, :wiki
+    assert_menu_contains_item_named :project_settings_menu, :repository
+    assert_menu_contains_item_named :project_settings_menu, :boards
+    assert_menu_contains_item_named :project_settings_menu, :activities
   end
 end


### PR DESCRIPTION
Back the Project Settings Menu with a MenuManager

Create parallel helper method, render_menu_tabs, so that other extisting
tab menus can be moved over at an appropriate time.

Let me know if it needs to be reworked to any ChiliProject "standards"
