### PR TITLE
Allow projects to override mail emission address

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -176,6 +176,7 @@ class ProjectsController < ApplicationController
     @trackers = Tracker.all
     @repository ||= @project.repository
     @wiki ||= @project.wiki
+    p @project
   end
   
   def edit

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -176,7 +176,6 @@ class ProjectsController < ApplicationController
     @trackers = Tracker.all
     @repository ||= @project.repository
     @wiki ||= @project.wiki
-    p @project
   end
   
   def edit

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -38,6 +38,7 @@ class Mailer < ActionMailer::Base
   #   issue_add(issue) => tmail object
   #   Mailer.deliver_issue_add(issue) => sends an email to issue recipients
   def issue_add(issue)
+    from_project issue
     redmine_headers 'Project' => issue.project.identifier,
                     'Issue-Id' => issue.id,
                     'Issue-Author' => issue.author.login,
@@ -59,6 +60,7 @@ class Mailer < ActionMailer::Base
   #   Mailer.deliver_issue_edit(journal) => sends an email to issue recipients
   def issue_edit(journal)
     issue = journal.journalized.reload
+    from_project issue
     redmine_headers 'Project' => issue.project.identifier,
                     'Issue-Id' => issue.id,
                     'Issue-Author' => issue.author.login,
@@ -98,6 +100,7 @@ class Mailer < ActionMailer::Base
   #   document_added(document) => tmail object
   #   Mailer.deliver_document_added(document) => sends an email to the document's project recipients
   def document_added(document)
+    from_project document
     redmine_headers 'Project' => document.project.identifier,
                     'Type' => "Document"
     recipients document.recipients
@@ -130,6 +133,7 @@ class Mailer < ActionMailer::Base
       added_to = "#{l(:label_document)}: #{container.title}"
       recipients container.recipients
     end
+    from_project container
     redmine_headers 'Project' => container.project.identifier,
                     'Type' => "Attachment"
     subject "[#{container.project.name}] #{l(:label_attachment_new)}"
@@ -145,6 +149,7 @@ class Mailer < ActionMailer::Base
   #   news_added(news) => tmail object
   #   Mailer.deliver_news_added(news) => sends an email to the news' project recipients
   def news_added(news)
+    from_project news
     redmine_headers 'Project' => news.project.identifier,
                     'Type' => "News"
     message_id news
@@ -161,6 +166,7 @@ class Mailer < ActionMailer::Base
   #   message_posted(message) => tmail object
   #   Mailer.deliver_message_posted(message) => sends an email to the recipients
   def message_posted(message)
+    from_project message
     redmine_headers 'Project' => message.project.identifier,
                     'Topic-Id' => (message.parent_id || message.id),
                     'Type' => "Forum"
@@ -180,6 +186,7 @@ class Mailer < ActionMailer::Base
   #   wiki_content_added(wiki_content) => tmail object
   #   Mailer.deliver_wiki_content_added(wiki_content) => sends an email to the project's recipients
   def wiki_content_added(wiki_content)
+    from_project wiki_content
     redmine_headers 'Project' => wiki_content.project.identifier,
                     'Wiki-Page-Id' => wiki_content.page.id,
                     'Type' => "Wiki"
@@ -198,6 +205,7 @@ class Mailer < ActionMailer::Base
   #   wiki_content_updated(wiki_content) => tmail object
   #   Mailer.deliver_wiki_content_updated(wiki_content) => sends an email to the project's recipients
   def wiki_content_updated(wiki_content)
+    from_project wiki_content
     redmine_headers 'Project' => wiki_content.project.identifier,
                     'Wiki-Page-Id' => wiki_content.page.id,
                     'Type' => "Wiki"
@@ -355,6 +363,13 @@ class Mailer < ActionMailer::Base
   end
 
   private
+  # override from address to use project-specific setting
+  def from_project(container)
+    unless container.nil? or container.project.nil? or container.project.mail_from.empty?
+      from container.project.mail_from
+    end  
+  end
+  
   def initialize_defaults(method_name)
     super
     @initial_language = current_language

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -365,7 +365,7 @@ class Mailer < ActionMailer::Base
   private
   # override from address to use project-specific setting
   def from_project(container)
-    unless container.nil? or container.project.nil? or container.project.mail_from.empty?
+    unless container.nil? || container.project.nil? || container.project.mail_from.nil? || container.project.mail_from.empty?
       from container.project.mail_from
     end  
   end

--- a/app/models/mailer.rb
+++ b/app/models/mailer.rb
@@ -365,7 +365,7 @@ class Mailer < ActionMailer::Base
   private
   # override from address to use project-specific setting
   def from_project(container)
-    unless container.nil? || container.project.nil? || container.project.mail_from.nil? || container.project.mail_from.empty?
+    if container.present? && container.project.present? && container.project.mail_from.present?
       from container.project.mail_from
     end  
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -531,7 +531,8 @@ class Project < ActiveRecord::Base
     'custom_field_values',
     'custom_fields',
     'tracker_ids',
-    'issue_custom_field_ids'
+    'issue_custom_field_ids',
+    'mail_from'
 
   safe_attributes 'enabled_module_names',
     :if => lambda {|project, user| project.new_record? || user.allowed_to?(:select_project_modules, project) }

--- a/app/views/projects/_form.rhtml
+++ b/app/views/projects/_form.rhtml
@@ -14,6 +14,7 @@
 <br /><em><%= l(:text_length_between, :min => 1, :max => Project::IDENTIFIER_MAX_LENGTH) %> <%= l(:text_project_identifier_info) %></em>
 <% end %></p>
 <p><%= f.text_field :homepage, :size => 60 %></p>
+<p><%= f.text_field :mail_from, :size => 125 %></p>
 <p><%= f.check_box :is_public %></p>
 <%= wikitoolbar_for 'project_description' %>
 

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -243,6 +243,7 @@ bg:
   field_user: Потребител
   field_principal: Principal
   field_role: Роля
+  field_mail_from: E-mail адрес за емисии
   field_homepage: Начална страница
   field_is_public: Публичен
   field_parent: Подпроект на

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -232,6 +232,7 @@ bs:
   field_fixed_version: Ciljna verzija
   field_user: Korisnik
   field_role: Uloga
+  field_mail_from: Mail adresa - pošaljilac
   field_homepage: Naslovna strana
   field_is_public: Javni
   field_parent: Podprojekt od

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -244,6 +244,7 @@ ca:
   field_user: Usuari
   field_principal: Principal
   field_role: Rol
+  field_mail_from: Adreça de correu electrònic d'emissió
   field_homepage: Pàgina web
   field_is_public: Públic
   field_parent: Subprojecte de

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -217,6 +217,7 @@ cs:
   field_fixed_version: Cílová verze
   field_user: Uživatel
   field_role: Role
+  field_mail_from: Odesílat emaily z adresy
   field_homepage: Domovská stránka
   field_is_public: Veřejný
   field_parent: Nadřazený projekt

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -230,6 +230,7 @@ da:
   field_fixed_version: Target version
   field_user: Bruger
   field_role: Rolle
+  field_mail_from: Afsender-email
   field_homepage: Hjemmeside
   field_is_public: Offentlig
   field_parent: Underprojekt af

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -258,6 +258,7 @@ de:
   field_user: Benutzer
   field_principal: Auftraggeber
   field_role: Rolle
+  field_mail_from: E-Mail-Absender
   field_homepage: Projekt-Homepage
   field_is_public: Öffentlich
   field_parent: Unterprojekt von

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -227,6 +227,7 @@ el:
   field_fixed_version: Στόχος έκδοσης
   field_user: Χρήστης
   field_role: Ρόλος
+  field_mail_from: Μετάδοση διεύθυνσης email
   field_homepage: Αρχική σελίδα
   field_is_public: Δημόσιο
   field_parent: Επιμέρους έργο του

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -237,6 +237,7 @@ en-GB:
   field_fixed_version: Target version
   field_user: User
   field_role: Role
+  field_mail_from: Emission email address
   field_homepage: Homepage
   field_is_public: Public
   field_parent: Subproject of

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,6 +243,7 @@ en:
   field_user: User
   field_principal: Principal
   field_role: Role
+  field_mail_from: Emission email address
   field_homepage: Homepage
   field_is_public: Public
   field_parent: Subproject of

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -277,6 +277,7 @@ es:
   field_firstname: Nombre
   field_fixed_version: Versión prevista
   field_hide_mail: Ocultar mi dirección de correo
+  field_mail_from: Correo desde el que enviar mensajes
   field_homepage: Sitio web
   field_host: Anfitrión
   field_hours: Horas

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -236,6 +236,7 @@ eu:
   field_fixed_version: Helburuko bertsioa
   field_user: Erabiltzilea
   field_role: Rola
+  field_mail_from: Igorlearen eposta helbidea
   field_homepage: Orri nagusia
   field_is_public: Publikoa
   field_parent: "Honen azpiproiektua:"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -238,6 +238,7 @@ fi:
   field_fixed_version: Kohdeversio
   field_user: Käyttäjä
   field_role: Rooli
+  field_mail_from: Lähettäjän sähköpostiosoite
   field_homepage: Kotisivu
   field_is_public: Julkinen
   field_parent: Aliprojekti

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -250,6 +250,7 @@ fr:
   field_fixed_version: Version cible
   field_user: Utilisateur
   field_role: Rôle
+  field_mail_from: Adresse d'émission
   field_homepage: "Site web "
   field_is_public: Public
   field_parent: Sous-projet de

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -254,6 +254,7 @@ gl:
   field_firstname: Nome
   field_fixed_version: Versión prevista
   field_hide_mail: Ocultar a miña dirección de correo
+  field_mail_from: Correo dende o que enviar mensaxes
   field_homepage: Sitio web
   field_host: Anfitrión
   field_hours: Horas

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -246,6 +246,7 @@ he:
   field_user: מתשמש
   field_principal: מנהל
   field_role: תפקיד
+  field_mail_from: כתובת שליחת דוא"ל
   field_homepage: דף הבית
   field_is_public: פומבי
   field_parent: תת פרויקט של

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -232,6 +232,7 @@ hr:
   field_fixed_version: Verzija
   field_user: Korisnik
   field_role: Uloga
+  field_mail_from: Izvorna adresa e-pošte
   field_homepage: Naslovnica
   field_is_public: Javni projekt
   field_parent: Potprojekt od

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -236,6 +236,7 @@
   field_fixed_version: Cél verzió
   field_user: Felhasználó
   field_role: Szerepkör
+  field_mail_from: Kibocsátó e-mail címe
   field_homepage: Weboldal
   field_is_public: Nyilvános
   field_parent: Szülő projekt

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -230,6 +230,7 @@ id:
   field_fixed_version: Versi target
   field_user: Pengguna
   field_role: Peran
+  field_mail_from: Emisi alamat email
   field_homepage: Halaman web
   field_is_public: Publik
   field_parent: Subproyek dari

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -209,6 +209,7 @@ it:
   field_fixed_version: Versione prevista
   field_user: Utente
   field_role: Ruolo
+  field_mail_from: Indirizzo sorgente email
   field_homepage: Homepage
   field_is_public: Pubblico
   field_parent: Sottoprogetto di

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -265,6 +265,7 @@ ja:
   field_user: ユーザ
   field_principal: 主体
   field_role: ロール
+  field_mail_from: 送信元メールアドレス
   field_homepage: ホームページ
   field_is_public: 公開
   field_parent: 親プロジェクト名

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -275,6 +275,7 @@ ko:
   field_fixed_version: 목표버전
   field_user: 사용자
   field_role: 역할
+  field_mail_from: 발신 메일 주소
   field_homepage: 홈페이지
   field_is_public: 공개
   field_parent: 상위 프로젝트

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -285,6 +285,7 @@ lt:
   field_fixed_version: Tikslinė versija
   field_user: Vartotojas
   field_role: Vaidmuo
+  field_mail_from: Emisijos elektroninio pašto adresas
   field_homepage: Pagrindinis puslapis
   field_is_public: Viešas
   field_parent: Priklauso projektui

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -228,6 +228,7 @@ lv:
   field_fixed_version: Mērķa versija
   field_user: Lietotājs
   field_role: Loma
+  field_mail_from: E-pasta adrese informācijas nosūtīšanai
   field_homepage: Vietne
   field_is_public: Publisks
   field_parent: Apakšprojekts projektam

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -241,6 +241,7 @@ mk:
   field_user: Корисник
   field_principal: Principal
   field_role: Улога
+  field_mail_from: Emission email address
   field_homepage: Веб страна
   field_is_public: Јавен
   field_parent: Подпроект на

--- a/config/locales/mn.yml
+++ b/config/locales/mn.yml
@@ -232,6 +232,7 @@ mn:
   field_fixed_version: Хувилбар
   field_user: Хэрэглэгч
   field_role: Хандалтын эрх
+  field_mail_from: Ямар имэйл хаяг үүсгэх
   field_homepage: Нүүр хуудас
   field_is_public: Олон нийтийн
   field_parent: Эцэг төсөл нь

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -224,6 +224,7 @@ nl:
   field_firstname: Voornaam
   field_fixed_version: Versie
   field_hide_mail: Verberg mijn e-mailadres
+  field_mail_from: Afzender e-mail adres
   field_homepage: Homepage
   field_host: Host
   field_hours: Uren

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -207,6 +207,7 @@
   field_fixed_version: Mål-versjon
   field_user: Bruker
   field_role: Rolle
+  field_mail_from: Avsenders e-post
   field_homepage: Hjemmeside
   field_is_public: Offentlig
   field_parent: Underprosjekt til

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -241,6 +241,7 @@ pl:
   field_firstname: Imię
   field_fixed_version: Wersja docelowa
   field_hide_mail: Ukryj mój adres email
+  field_mail_from: Adres email wysyłki
   field_homepage: Strona www
   field_host: Host
   field_hours: Godzin

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -240,6 +240,7 @@ pt-BR:
   field_fixed_version: Versão
   field_user: Usuário
   field_role: Cargo
+  field_mail_from: E-mail enviado de
   field_homepage: Página do projeto
   field_is_public: Público
   field_parent: Sub-projeto de

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -225,6 +225,7 @@ pt:
   field_fixed_version: Versão
   field_user: Utilizador
   field_role: Função
+  field_mail_from: E-mail enviado de
   field_homepage: Página
   field_is_public: Público
   field_parent: Sub-projecto de

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -212,6 +212,7 @@ ro:
   field_fixed_version: Versiune țintă
   field_user: Utilizator
   field_role: Rol
+  field_mail_from: Adresa de email a expeditorului
   field_homepage: Pagina principală
   field_is_public: Public
   field_parent: Sub-proiect al

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -325,6 +325,7 @@ ru:
   field_firstname: Имя
   field_fixed_version: Версия
   field_hide_mail: Скрывать мой email
+  field_mail_from: email адрес для передачи информации
   field_homepage: Стартовая страница
   field_host: Компьютер
   field_hours: час(а,ов)

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -211,6 +211,7 @@ sk:
   field_fixed_version: Priradené k verzii
   field_user: Užívateľ
   field_role: Rola
+  field_mail_from: Odosielať emaily z adresy
   field_homepage: Domovská stránka
   field_is_public: Verejný
   field_parent: Nadradený projekt

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -216,6 +216,7 @@ sl:
   field_fixed_version: Ciljna verzija
   field_user: Uporabnik
   field_role: Vloga
+  field_mail_from: E-naslov za emisijo
   field_homepage: Domača stran
   field_is_public: Javno
   field_parent: Podprojekt projekta

--- a/config/locales/sr-YU.yml
+++ b/config/locales/sr-YU.yml
@@ -241,6 +241,7 @@ sr-YU:
   field_user: Korisnik
   field_principal: Glavni
   field_role: Uloga
+  field_mail_from: E-adresa pošiljaoca
   field_homepage: Početna stranica
   field_is_public: Javno objavljivanje
   field_parent: Potprojekat od

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -241,6 +241,7 @@ sr:
   field_user: Корисник
   field_principal: Главни
   field_role: Улога
+  field_mail_from: Е-адреса пошиљаоца
   field_homepage: Почетна страница
   field_is_public: Јавно објављивање
   field_parent: Потпројекат од

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -285,6 +285,7 @@ sv:
   field_user: Användare
   field_principal: Principal
   field_role: Roll
+  field_mail_from: Avsändaradress
   field_homepage: Hemsida
   field_is_public: Publik
   field_parent: Underprojekt till

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -213,6 +213,7 @@ th:
   field_fixed_version: รุ่น
   field_user: ผู้ใช้
   field_role: บทบาท
+  field_mail_from: อีเมล์ที่ใช้ส่ง
   field_homepage: หน้าแรก
   field_is_public: สาธารณะ
   field_parent: โครงการย่อยของ

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -236,6 +236,7 @@ tr:
   field_fixed_version: Hedef Version
   field_user: Kullanıcı
   field_role: Rol
+  field_mail_from: Gönderici e-posta adresi
   field_homepage: Anasayfa
   field_is_public: Genel
   field_parent: 'Üst proje: '

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -207,6 +207,7 @@ uk:
   field_fixed_version: Target version
   field_user: Користувач
   field_role: Роль
+  field_mail_from: email адреса для передачі інформації
   field_homepage: Домашня сторінка
   field_is_public: Публічний
   field_parent: Підпроект

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -270,6 +270,7 @@ vi:
   field_fixed_version: Phiên bản
   field_user: Người dùng
   field_role: Quyền
+  field_mail_from: Emission email address
   field_homepage: Trang chủ
   field_is_public: Công cộng
   field_parent: Dự án con của

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -324,6 +324,7 @@
   field_user: 用戶
   field_principal: 原則
   field_role: 角色
+  field_mail_from: 寄件者電子郵件
   field_homepage: 網站首頁
   field_is_public: 公開
   field_parent: 父專案

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -248,6 +248,7 @@ zh:
   field_fixed_version: 目标版本
   field_user: 用户
   field_role: 角色
+  field_mail_from: 邮件发件人地址
   field_homepage: 主页
   field_is_public: 公开
   field_parent: 上级项目

--- a/db/migrate/20110414141209_add_mail_from_to_project.rb
+++ b/db/migrate/20110414141209_add_mail_from_to_project.rb
@@ -1,0 +1,9 @@
+class AddMailFromToProject < ActiveRecord::Migration
+  def self.up
+    add_column :projects, :mail_from, :string
+  end
+
+  def self.down
+    remove_column :projects, :mail_from
+  end
+end

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -244,3 +244,22 @@ issues_013:
   root_id: 13
   lft: 1
   rgt: 2
+issues_014: 
+  created_on: <%= 3.days.ago.to_date.to_s(:db) %>
+  project_id: 1
+  updated_on: <%= 1.day.ago.to_date.to_s(:db) %>
+  priority_id: 4
+  subject: Can't print recipes
+  id: 14
+  fixed_version_id: 
+  category_id: 1
+  description: Unable to print recipes
+  tracker_id: 1
+  assigned_to_id: 
+  author_id: 2
+  status_id: 1
+  start_date: <%= 1.day.ago.to_date.to_s(:db) %>
+  due_date: <%= 10.day.from_now.to_date.to_s(:db) %>
+  root_id: 1
+  lft: 1
+  rgt: 2

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -11,6 +11,7 @@ projects_001:
   parent_id: 
   lft: 1
   rgt: 10
+  mail_from: chiliproject@chiliproject.org 
 projects_002: 
   created_on: 2006-07-19 19:14:19 +02:00
   name: OnlineStore
@@ -23,6 +24,7 @@ projects_002:
   parent_id: 
   lft: 11
   rgt: 12
+  mail_from: 
 projects_003: 
   created_on: 2006-07-19 19:15:21 +02:00
   name: eCookbook Subproject 1
@@ -35,6 +37,7 @@ projects_003:
   parent_id: 1
   lft: 6
   rgt: 7
+  mail_from: 
 projects_004: 
   created_on: 2006-07-19 19:15:51 +02:00
   name: eCookbook Subproject 2
@@ -47,6 +50,7 @@ projects_004:
   parent_id: 1
   lft: 8
   rgt: 9
+  mail_from: 
 projects_005: 
   created_on: 2006-07-19 19:15:51 +02:00
   name: Private child of eCookbook
@@ -59,6 +63,7 @@ projects_005:
   parent_id: 1
   lft: 2
   rgt: 5
+  mail_from: 
 projects_006: 
   created_on: 2006-07-19 19:15:51 +02:00
   name: Child of private child
@@ -71,4 +76,4 @@ projects_006:
   parent_id: 5
   lft: 3
   rgt: 4
-  
+  mail_from:  

--- a/test/unit/mailer_test.rb
+++ b/test/unit/mailer_test.rb
@@ -165,6 +165,14 @@ class MailerTest < ActiveSupport::TestCase
     assert_nil mail.references
   end
   
+  def test_mail_from_overridden_by_project
+    issue = Issue.find(14)
+    Mailer.deliver_issue_add(issue)
+    mail = ActionMailer::Base.deliveries.last
+    assert_not_nil mail
+    assert_equal 'chiliproject@chiliproject.org', mail.from_addrs[0].address
+  end
+ 
   def test_issue_edit_message_id
     journal = Journal.find(1)
     Mailer.deliver_issue_edit(journal)


### PR DESCRIPTION
Allow per-project mail emission address settings.  Global settings will be used if the project-level mail emission address is left blank.
