### PR TITLE
[#379] Help controller headings rendered differently in Ruby 1.9

### DIFF
--- a/app/views/help/wiki_syntax.html.erb
+++ b/app/views/help/wiki_syntax.html.erb
@@ -9,7 +9,8 @@
     table td h3 { font-size: 1.2em; text-align: left; }
 <% end %>
 
-<h1><%= html_title "Wiki Syntax Quick Reference" %></h1>
+<% html_title "Wiki Syntax Quick Reference" %>
+<h1>Wiki Syntax Quick Reference</h1>
 
 <table width="100%">
 <tr><th colspan="3">Font Styles</th></tr>

--- a/app/views/help/wiki_syntax_detailed.html.erb
+++ b/app/views/help/wiki_syntax_detailed.html.erb
@@ -29,7 +29,8 @@
     .CodeRay .s  .dl { color:#710 }
 <% end %>
 
-<h1><a name="1" class="wiki-page"></a><%= html_title "Wiki Formatting" %></h1>
+<% html_title "Wiki Formatting" %>
+<h1><a name="1" class="wiki-page"></a>Wiki Formatting</h1>
 
     <h2><a name="2" class="wiki-page"></a>Links</h2>
 


### PR DESCRIPTION
This is the pull request for #[379](https://www.chiliproject.org/issues/379)
