### PR TITLE
Feature #418 - Disabling link to repository statistics for IE less then 9

### DIFF
--- a/app/views/repositories/_navigation.rhtml
+++ b/app/views/repositories/_navigation.rhtml
@@ -4,7 +4,7 @@
 
 <!--[if gt IE 8]><!-->
 <%= link_to l(:label_statistics), {:action => 'stats', :id => @project}, :class => 'icon icon-stats' %> |
-<!--[endif]-->
+<!--<![endif]-->
 
 <% form_tag({:action => controller.action_name, :id => @project, :path => to_path_param(@path), :rev => ''}, {:method => :get, :id => 'revision_selector'}) do -%>
   <!-- Branches Dropdown -->


### PR DESCRIPTION
This is an alternative pull request to fix #[418](https://www.chiliproject.org/issues/418) based on @ulferts' version in #60
