### PR TITLE
Removed explicit render in WikiController#show

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -77,7 +77,6 @@ class WikiController < ApplicationController
       end
     end
     @editable = editable?
-    render :action => 'show'
   end
   
   # edit an existing page or a new one

--- a/app/views/wiki/show.rhtml
+++ b/app/views/wiki/show.rhtml
@@ -57,7 +57,7 @@
 <% end %>
 
 <% content_for :sidebar do %>
-  <%= render :partial => 'sidebar' %>
+  <%= render :partial => 'wiki/sidebar' %>
 <% end %>
 
 <% html_title @page.pretty_title %>


### PR DESCRIPTION
- Allows for format extensions in plugins w/o giving a double-render
  error
- Updated Wiki#show template to specify 'wiki/sidebar' explicitly
  (vs. just 'sidebar')

Let me know if there is anything else you'd like to see done...or if you are not interested in accepting this.
