### PR TITLE
Add ruby-debug dependency for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem "coderay", "~> 0.9.7"
 gem "i18n", "~> 0.4.2"
 gem "rubytree", "~> 0.5.2", :require => 'tree'
 
+group :development do
+  gem 'ruby-debug'
+end
+
 group :test do
   gem 'shoulda', '~> 2.10.3'
   gem 'edavis10-object_daddy', :require => 'object_daddy'


### PR DESCRIPTION
I can't start my development server in debugging mode unless ruby-debug is in the Gemfile.  Not sure if there is a better way around this..
