### PR TITLE
Ticket/release v2.0.0/445 initial journal tracking

### DIFF
--- a/test/unit/journal_test.rb
+++ b/test/unit/journal_test.rb
@@ -58,4 +58,25 @@ class JournalTest < ActiveSupport::TestCase
     end
     assert_equal 0, ActionMailer::Base.deliveries.size
   end
+
+  test "creating the initial journal should track the changes from creation" do
+    @project = Project.generate!
+    issue = Issue.new do |i|
+      i.project = @project
+      i.subject = "Test initial journal"
+      i.tracker = @project.trackers.first
+      i.author = User.generate!
+      i.description = "Some content"
+    end
+
+    assert_difference("Journal.count") do
+      assert issue.save
+    end
+    
+    journal = issue.reload.journals.first
+    assert_equal ["","Test initial journal"], journal.changes["subject"]
+    assert_equal [0, @project.id], journal.changes["project_id"]
+    assert_equal [nil, "Some content"], journal.changes["description"]
+  end
+  
 end

--- a/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
+++ b/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
@@ -45,7 +45,7 @@ module Redmine::Acts::Journalized
       base.class_eval do
         include InstanceMethods
 
-        after_update :merge_journal_changes
+        after_save :merge_journal_changes
       end
     end
 


### PR DESCRIPTION
So the initial journal would have the changes from an Object#new
to the created version of the Object. Also includes a change to the
database migration in order to create these initial journals for
all journaled Objects.
