### PR TITLE
Removed unnecessary class on changeset partial [refs: #472]

### DIFF
--- a/app/views/issues/_changesets.rhtml
+++ b/app/views/issues/_changesets.rhtml
@@ -3,7 +3,7 @@
     <p><%= link_to_revision(changeset, changeset.project,
                             :text => "#{l(:label_revision)} #{changeset.format_identifier}") %><br />
         <span class="author"><%= authoring(changeset.committed_on, changeset.author) %></span></p>
-    <div class="changeset-changes">
+    <div>
         <%= textilizable(changeset, :comments) %>
     </div>
     </div>


### PR DESCRIPTION
The the encapsulating div has a class of "changeset-changes" which is unnecessary in the context of this page (issues/show)...and this page seems to be the only one using this partial, so removing the class results in the default list styling, which is consistent with the "Latest Revisions" section under the "Repository" tab (on the bottom of the "initial" view when you click "Repository"). This change does not affect the view shown on the revision-specific diff page, which does require the "changeset-changes" class for styling purposes.
