### PR TITLE
[Bug #477] Getting rid of "rake/rdoctask is deprecated." warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "rails", "2.3.12"
 gem "coderay", "~> 0.9.7"
 gem "i18n", "~> 0.4.2"
 gem "rubytree", "~> 0.5.2", :require => 'tree'
-gem "rdoc"
+gem "rdoc", ">= 2.4.2"
 
 group :test do
   gem 'shoulda', '~> 2.10.3'

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,6 @@ require(File.join(File.dirname(__FILE__), 'config', 'boot'))
 
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 require 'tasks/rails'


### PR DESCRIPTION
This is the pull request for #[477](https://www.chiliproject.org/issues/477).
