### PR TITLE
Fix for deep links to PDF URIs [refs: #485]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,6 +132,7 @@ class ApplicationController < ActionController::Base
       respond_to do |format|
         format.html { redirect_to :controller => "account", :action => "login", :back_url => url }
         format.atom { redirect_to :controller => "account", :action => "login", :back_url => url }
+        format.pdf  { redirect_to :controller => "account", :action => "login", :back_url => url }
         format.xml  { head :unauthorized, 'WWW-Authenticate' => 'Basic realm="ChiliProject API"' }
         format.js   { head :unauthorized, 'WWW-Authenticate' => 'Basic realm="ChiliProject API"' }
         format.json { head :unauthorized, 'WWW-Authenticate' => 'Basic realm="ChiliProject API"' }


### PR DESCRIPTION
Added format.pdf block for ApplicationController#require_login to fix issue outlined in issue [#485](https://www.chiliproject.org/issues/485).

This update will make the request redirect to the login page, and then back to the original URL, as you would expect...versus rendering a blank (white) screen as it does today.
