### PR TITLE
Added hook for additional wiki formats [refs #488]

### DIFF
--- a/app/views/wiki/show.rhtml
+++ b/app/views/wiki/show.rhtml
@@ -49,6 +49,7 @@
   <%= f.link_to 'Atom', :url => {:controller => 'activities', :action => 'index', :id => @project, :show_wiki_edits => 1, :key => User.current.rss_key} %>
   <%= f.link_to 'HTML', :url => {:id => @page.title, :version => @content.version} %>
   <%= f.link_to 'TXT', :url => {:id => @page.title, :version => @content.version} %>
+  <%= call_hook(:view_wiki_show_other_formats, {:link_builder => f, :url_params => {:id => @page.title, :version => @content.version}}) %>
 <% end if User.current.allowed_to?(:export_wiki_pages, @project) %>
 
 <% content_for :header_tags do %>


### PR DESCRIPTION
- Allows plugins to add to the list of supported export formats at the
  bottom of the Wiki#show view template (such as PDF support ;-))
