### PR TITLE
Fix params encoding

### DIFF
--- a/config/initializers/utf8_params.rb
+++ b/config/initializers/utf8_params.rb
@@ -1,0 +1,20 @@
+raise "Check if this is still needed on " + Rails.version unless Rails.version == '2.3.12'
+class ActionController::Base
+  def force_utf8_params
+    traverse = lambda do |object, block|
+      if object.kind_of?(Hash)
+        object.each_value { |o| traverse.call(o, block) }
+      elsif object.kind_of?(Array)
+        object.each { |o| traverse.call(o, block) }
+      else
+        block.call(object)
+      end
+      object
+    end
+    force_encoding = lambda do |o|
+      o.force_encoding(Encoding::UTF_8) if o.respond_to?(:force_encoding)
+    end
+    traverse.call(params, force_encoding)
+  end
+  before_filter :force_utf8_params
+end


### PR DESCRIPTION
This fixes [#524](https://www.chiliproject.org/issues/524); I am not convinced by the "duplicate" status of this bug, and anyway, it has not been fixed yet.

It took me some time, but in my specific case I could track it down to the params hash containing ASCII-8BIT strings, even though my browser was set to UTF-8, I launched ruby with `-KU` and I had added

```
Encoding.default_external = Encoding::UTF_8
Encoding.default_internal = Encoding::UTF_8
```

to my `config/environment.rb` file. And I did add `encoding: UTF-8` to my database configuration, but I do not think it is relevant here.
