### PR TITLE
[#573] acts_as_searchable definition in WikiPage may be insufficient and cause SQL errors

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -26,7 +26,7 @@ class WikiPage < ActiveRecord::Base
                 :datetime => :created_on,
                 :url => Proc.new {|o| {:controller => 'wiki', :action => 'show', :project_id => o.wiki.project, :id => o.title}}
 
-  acts_as_searchable :columns => ['title', 'text'],
+  acts_as_searchable :columns => ["#{WikiPage.table_name}.title", "#{WikiContent.table_name}.text"],
                      :include => [{:wiki => :project}, :content],
                      :project_key => "#{Wiki.table_name}.project_id"
 


### PR DESCRIPTION
This is the pull request for #[573](https://www.chiliproject.org/issues/573)
