### PR TITLE
Prevent large production database migration from consuming all the RAM on the server

### DIFF
--- a/db/migrate/20100714111653_build_initial_journals_for_acts_as_journalized.rb
+++ b/db/migrate/20100714111653_build_initial_journals_for_acts_as_journalized.rb
@@ -37,7 +37,7 @@ class BuildInitialJournalsForActsAsJournalized < ActiveRecord::Migration
         activity_type = p.activity_provider_options.keys.first
 
         # Create initial journals
-        p.find(:all).each do |o|
+        p.find_each(:batch_size => 100 ) do |o|
           # Using rescue and save! here because either the Journal or the
           # touched record could fail. This will catch either error and continue
           begin


### PR DESCRIPTION
Prevent large production databases from consuming all the RAM on the server and causing the migration to take forever. On a database with a large SVN repo, the Changesets ran for over two days before I gave up and cancelled it. After this change, the migration ran in under 10 minutes.
