### PR TITLE
[#640] Graciously handle deleted custom fields on issue history view.

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -798,6 +798,7 @@ de:
   label_project_copy_notifications: Sende Mailbenachrichtigungen beim Kopieren des Projekts.
   label_principal_search: "Nach Benutzer oder Gruppe suchen:"
   label_user_search: "Nach Benutzer suchen:"
+  label_deleted_custom_field: '(gelöschtes benutzerdefiniertes Feld)'
 
   button_login: Anmelden
   button_submit: OK

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -812,6 +812,7 @@ en:
   label_additional_workflow_transitions_for_author: Additional transitions allowed when the user is the author
   label_notify_member_plural: Email issue updates
   label_path_encoding: Path encoding
+  label_deleted_custom_field: '(deleted custom field)'
 
   button_login: Login
   button_submit: Submit

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -793,6 +793,7 @@ fr:
   label_user_search: "Rechercher un utilisateur :"
   label_additional_workflow_transitions_for_author: Autorisations supplémentaires lorsque l'utilisateur a créé la demande
   label_additional_workflow_transitions_for_assignee: Autorisations supplémentaires lorsque la demande est assignée à l'utilisateur
+  label_deleted_custom_field: '(champ personnalisé supprimé)'
 
   button_login: Connexion
   button_submit: Soumettre

--- a/test/integration/issues_test.rb
+++ b/test/integration/issues_test.rb
@@ -199,5 +199,10 @@ class IssuesTest < ActionController::IntegrationTest
           :content => new_tester.name
         }
       }
+
+    # Test for deleted custom field handling
+    @field.destroy
+    get "/issues/#{issue.id}"
+    assert_response :success
   end
 end

--- a/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/vendor/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -83,9 +83,15 @@ module JournalFormatter
   end
 
   def format_custom_value_detail(custom_field, values, no_html)
-    label = custom_field.name
-    old_value = format_value(values.first, custom_field.field_format) if values.first
-    value = format_value(values.last, custom_field.field_format) if values.last
+    if custom_field
+      label = custom_field.name
+      old_value = format_value(values.first, custom_field.field_format) if values.first
+      value = format_value(values.last, custom_field.field_format) if values.last
+    else
+      label = l(:label_deleted_custom_field)
+      old_value = values.first
+      value = values.last
+    end
 
     [label, old_value, value]
   end


### PR DESCRIPTION
The issue history view currently crashes when trying to show attributes of deleted custom fields. This replaces the name of the deleted custom field by a generic message, the formatting of the custom field's values is lost though.
