### PR TITLE
Pulls/671/error messages

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -91,7 +91,7 @@ class AccountController < ApplicationController
         end
       else
         @user.login = params[:user][:login]
-        @user.password, @user.password_confirmation = params[:password], params[:password_confirmation]
+        @user.password, @user.password_confirmation = params[:user][:password], params[:user][:password_confirmation]
 
         case Setting.self_registration
         when '1'

--- a/app/views/account/register.rhtml
+++ b/app/views/account/register.rhtml
@@ -10,11 +10,11 @@
 <%= text_field 'user', 'login', :size => 25 %></p>
 
 <p><label for="password"><%=l(:field_password)%> <span class="required">*</span></label>
-<%= password_field_tag 'password', nil, :size => 25  %><br />
+<%= password_field 'user', 'password', :size => 25  %><br />
 <em><%= l(:text_caracters_minimum, :count => Setting.password_min_length) %></em></p>
 
 <p><label for="password_confirmation"><%=l(:field_password_confirmation)%> <span class="required">*</span></label>
-<%= password_field_tag 'password_confirmation', nil, :size => 25  %></p>
+<%= password_field 'user', 'password_confirmation', :size => 25  %></p>
 <% end %>
 
 <p><label for="user_firstname"><%=l(:field_firstname)%> <span class="required">*</span></label>

--- a/config/initializers/10-patches.rb
+++ b/config/initializers/10-patches.rb
@@ -57,6 +57,59 @@ end
 
 module ActionView
   module Helpers
+    module ActiveRecordHelper
+      def error_messages_for(*params)
+        options = params.extract_options!.symbolize_keys
+
+        if object = options.delete(:object)
+          objects = Array.wrap(object)
+        else
+          objects = params.collect {|object_name| instance_variable_get("@#{object_name}") }.compact
+        end
+
+
+        count  = objects.inject(0) {|sum, object| sum + object.errors.count }
+        unless count.zero?
+          html = {}
+          [:id, :class].each do |key|
+            if options.include?(key)
+              value = options[key]
+              html[key] = value unless value.blank?
+            else
+              html[key] = 'errorExplanation'
+            end
+          end
+          options[:object_name] ||= params.first
+
+          I18n.with_options :locale => options[:locale], :scope => [:activerecord, :errors, :template] do |locale|
+            header_message = if options.include?(:header_message)
+              options[:header_message]
+            else
+              object_name = options[:object_name].to_s
+              object_name = I18n.t(object_name, :default => object_name.gsub('_', ' '), :scope => [:activerecord, :models], :count => 1)
+              locale.t :header, :count => count, :model => object_name
+            end
+            message = options.include?(:message) ? options[:message] : locale.t(:body)
+
+            error_messages = objects.sum {|object| object.errors.full_messages.each_with_index.map do |msg,index|
+              # Generating unique identifier in order to jump directly to the field with the error
+              object_identifier = (object_name.parameterize("_")).to_s  + "_" + (object.errors.to_a.at(index).first) + "_error"
+              content_tag(:li, content_tag(:a,(ERB::Util.html_escape(msg)), :href => "#" + object_identifier, :class => "afocus"))
+            end}.join.html_safe
+
+            contents = ''
+            contents << content_tag(options[:header_tag] || :h2, header_message) unless header_message.blank?
+            contents << content_tag(:p, message) unless message.blank?
+            contents << content_tag(:ul, error_messages)
+
+            content_tag(:div, contents.html_safe, html)
+          end
+        else
+          ''
+        end
+      end
+    end
+
     module DateHelper
       # distance_of_time_in_words breaks when difference is greater than 30 years
       def distance_of_date_in_words(from_date, to_date = 0, options = {})
@@ -76,7 +129,34 @@ module ActionView
   end
 end
 
-ActionView::Base.field_error_proc = Proc.new{ |html_tag, instance| "#{html_tag}" }
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  if html_tag.include?("<label")
+    html_tag.to_s
+  else
+    object_identifier = (instance.instance_variable_get("@object_name").parameterize).to_s + "_" + (instance.instance_variable_get("@method_name"))
+
+    # select boxes used name_id whereas the validation uses name
+    # we have to cut the '_id' of in order for the field to match
+    if (html_tag.include?("<select") or html_tag.include?('type="checkbox"'))
+      object_identifier = object_identifier[0..-4]
+    end
+    object_identifier = object_identifier + "_error"
+    "<span id='#{object_identifier}' class=\"errorSpan\"><a name=\"#{object_identifier}\"></a>#{html_tag}</span>"
+  end
+end
+
+class ActiveRecord::Errors
+  def on_with_id_handling(attribute)
+    attribute = attribute.to_s
+    if attribute.ends_with? '_id'
+      on_without_id_handling(attribute) || on_without_id_handling(attribute[0..-4])
+    else
+      on_without_id_handling(attribute)
+    end
+  end
+
+  alias_method_chain :on, :id_handling
+end
 
 # Adds :async_smtp and :async_sendmail delivery methods
 # to perform email deliveries asynchronously

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -359,6 +359,7 @@ Ajax.Responders.register({
         if ($('ajax-indicator') && Ajax.activeRequestCount == 0) {
             Element.hide('ajax-indicator');
         }
+        addClickEventToAllErrorMessages();
     }
 });
 
@@ -367,5 +368,25 @@ function hideOnLoad() {
   	el.hide();
 	});
 }
+
+function addClickEventToAllErrorMessages() {
+  $$('a.afocus').each(function(a) {
+    $(a).observe('click', function(event) {
+      var field;
+      field = $($(a).readAttribute('href').substr(1));
+      if (field == null) {
+        // Cut off '_id' (necessary for select boxes)
+        field = $($(a).readAttribute('href').substr(1).concat('_id'));
+      }
+      field.down('input, textarea, select').focus();
+      Event.stop(event);
+      return false;
+    });
+  });
+}
+$(document).observe('dom:loaded', function() {
+  // Focus on field with error
+  addClickEventToAllErrorMessages();
+});
 
 Event.observe(window, 'load', hideOnLoad);

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -385,6 +385,11 @@ function addClickEventToAllErrorMessages() {
   });
 }
 $(document).observe('dom:loaded', function() {
+  // Set focus on first error message
+  var focus = $$('a.afocus').first();
+  if (focus != undefined) {
+    focus.focus();
+  }
   // Focus on field with error
   addClickEventToAllErrorMessages();
 });

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -473,6 +473,20 @@ input#principal_search, input#user_search {width:100%}
 	border: 2px solid;
 }
 
+span.errorSpan {
+  font-weight: bold;
+}
+
+span.errorSpan textarea {
+  border: 2px solid red;
+}
+span.errorSpan select {
+  border: 2px solid red;
+}
+span.errorSpan input {
+  border: 2px solid red;
+}
+
 div.flash {margin-top: 8px;}
 
 div.flash.error, #errorExplanation {

--- a/test/integration/account_test.rb
+++ b/test/integration/account_test.rb
@@ -124,8 +124,7 @@ class AccountTest < ActionController::IntegrationTest
     Setting.self_registration = '1'
     Token.delete_all
 
-    post 'account/register', :user => {:login => "newuser", :language => "en", :firstname => "New", :lastname => "User", :mail => "newuser@foo.bar"},
-                             :password => "newpass", :password_confirmation => "newpass"
+    post 'account/register', :user => {:login => "newuser", :language => "en", :firstname => "New", :lastname => "User", :mail => "newuser@foo.bar", :password => "newpass", :password_confirmation => "newpass"}
     assert_redirected_to '/login'
     assert !User.find_by_login('newuser').active?
 


### PR DESCRIPTION
This pull request contains the following features:
- errors messages (which are created with 'error_messages_for') will be links that anchor the corresponding field
- fields containing errors are highlighted with a red border
- clicking on an error message (in case javascript enabled) will focus the input field
- the first error messages gets the focus - this is necessary because blind users would not notice the change/the error
