### PR TITLE
[#698] Fix issue queries on Ruby 1.9

### DIFF
--- a/app/views/queries/_filters.rhtml
+++ b/app/views/queries/_filters.rhtml
@@ -97,11 +97,11 @@ Event.observe(document,"dom:loaded", apply_filters_observer);
         </select>
         <%= link_to_function image_tag('bullet_toggle_plus.png'), "toggle_multi_select('#{field}');", :style => "vertical-align: bottom;" %>
     <% when :date, :date_past %>
-        <%= text_field_tag "v[#{field}][]", query.values_for(field), :id => "values_#{field}", :size => 3, :class => "select-small" %> <%= l(:label_day_plural) %>
+        <%= text_field_tag "v[#{field}][]", query.values_for(field).try(:first), :id => "values_#{field}", :size => 3, :class => "select-small" %> <%= l(:label_day_plural) %>
     <% when :string, :text %>
-        <%= text_field_tag "v[#{field}][]", query.values_for(field), :id => "values_#{field}", :size => 30, :class => "select-small" %>
+        <%= text_field_tag "v[#{field}][]", query.values_for(field).try(:first), :id => "values_#{field}", :size => 30, :class => "select-small" %>
     <% when :integer %>
-        <%= text_field_tag "v[#{field}][]", query.values_for(field), :id => "values_#{field}", :size => 3, :class => "select-small" %>
+        <%= text_field_tag "v[#{field}][]", query.values_for(field).try(:first), :id => "values_#{field}", :size => 3, :class => "select-small" %>
     <% end %>
     </div>
     <script type="text/javascript">toggle_filter('<%= field %>');</script>


### PR DESCRIPTION
This should fix the issue query problem described in #698. `Query#values_for(field)` returns an array which is passed to the `text_field_tag` helper method. This works on Ruby 1.8, because `["test"].to_s` returns `test`, but on Ruby 1.9 it returns `["test"]`.

Using the first element of this array as parameter for `text_field_tag` seems better than relying on `Array#to_s`.

I did a quick test on Ruby 1.8.7 as well, it seems to work but it should be tested by someone else as well.
