### PR TITLE
[#711] Fix TabularFormBuilder on Ruby 1.9

### DIFF
--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -22,7 +22,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     super
   end
 
-  (field_helpers - %w(radio_button hidden_field fields_for) + %w(date_select)).each do |selector|
+  (field_helpers.map(&:to_s) - %w(radio_button hidden_field fields_for) + %w(date_select)).each do |selector|
     src = <<-END_SRC
     def #{selector}(field, options = {})
       label_for_field(field, options) + super


### PR DESCRIPTION
This pull request fixes `TabularFormBuilder` on Ruby 1.9.

On Ruby 1.9, the `field_helpers` method returns an array of symbols instead of an array of string. (It uses `FormHelper,instance_methods` to get the list of helpers. The `instance_methods` method has been change in Ruby 1.9 to return symbols instead of strings.)

The `map(&:to_s)` solution should work on Ruby 1.8.7 as well.
