### PR TITLE
Encloses since date in single quotes. This was causing git to respond wi...

### DIFF
--- a/lib/redmine/scm/adapters/git_adapter.rb
+++ b/lib/redmine/scm/adapters/git_adapter.rb
@@ -176,7 +176,7 @@ module Redmine
           from_to << "#{identifier_from}.." if identifier_from
           from_to << "#{identifier_to}" if identifier_to
           cmd_args << from_to if !from_to.empty?
-          cmd_args << "--since=#{options[:since].strftime("%Y-%m-%d %H:%M:%S")}" if options[:since]
+          cmd_args << "--since='#{options[:since].strftime("%Y-%m-%d %H:%M:%S")}'" if options[:since]
           cmd_args << "--" << scm_iconv(@path_encoding, 'UTF-8', path) if path && !path.empty?
 
           scm_cmd *cmd_args do |io|


### PR DESCRIPTION
...th fatal: Unknown Object and preventing revisions from being updated.

This is what the current redmine code generates:
 git log --no-color --encoding=UTF-8 --raw --date=iso --pretty=fuller --reverse --all --since=2011-11-15 17:22:55

Run in any local repo you have and it will tank. 

Running with quotes returns the expected output and allows #fetch_changesets to run successfully. 

git log --no-color --encoding=UTF-8 --raw --date=iso --pretty=fuller --reverse --all --since='2011-11-15 17:22:55'
