### PR TITLE
Issue #760 Adds a quick search view that can be replaced by plugins if necessary

### DIFF
--- a/app/views/layouts/base.rhtml
+++ b/app/views/layouts/base.rhtml
@@ -35,14 +35,7 @@
 <div id="header">
     <% if User.current.logged? || !Setting.login_required? %>
     <div id="quick-search">
-        <% form_tag({:controller => 'search', :action => 'index', :id => @project}, :method => :get ) do %>
-        <%= hidden_field_tag(controller.default_search_scope, 1, :id => nil) if controller.default_search_scope %>
-        <label for='q'>
-          <%= link_to l(:label_search), {:controller => 'search', :action => 'index', :id => @project}, :accesskey => accesskey(:search) %>:
-        </label>
-        <%= text_field_tag 'q', @question, :size => 20, :class => 'small', :accesskey => accesskey(:quick_search) %>
-        <% end %>
-        <%= render_project_jump_box %>
+      <%= render :partial => 'search/quick_search' %>
     </div>
     <% end %>
 

--- a/app/views/search/_quick_search.html.erb
+++ b/app/views/search/_quick_search.html.erb
@@ -1,0 +1,8 @@
+<% form_tag({:controller => 'search', :action => 'index', :id => @project}, :method => :get ) do %>
+<%= hidden_field_tag(controller.default_search_scope, 1, :id => nil) if controller.default_search_scope %>
+<label for='q'>
+  <%= link_to l(:label_search), {:controller => 'search', :action => 'index', :id => @project}, :accesskey => accesskey(:search) %>:
+</label>
+<%= text_field_tag 'q', @question, :size => 20, :class => 'small', :accesskey => accesskey(:quick_search) %>
+<% end %>
+<%= render_project_jump_box %>


### PR DESCRIPTION
Very simple patch that moves the quick_search to a partial that can be overridden in a plugin.  I am trying to see if I can get a full text search system in place as a plugin using Sunspot and Solr.  Not being able to replace the quick search really makes the whole development effort moot.  
