### PR TITLE
#826 toolbar icons

### DIFF
--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1547,12 +1547,12 @@ h1.title {
 
 /* .button-large was too generic and targeted other pages with it's positioning */
 .title-bar .button-large {
-	position:absolute;
-	top:8px;
+	float: left;
+	padding: 2px 0 3px;
 }
 
 .button-large a {
-	padding:3px 9px;
+	line-height: 3.5;
 	display:block;
 	color:#6a0406;
 }
@@ -2310,6 +2310,7 @@ fieldset#filters div.add-filter {
 	margin:0;
 }
 .title-bar .contextual a.icon {
+	float: left;
 	line-height:3.5;
 	margin-right:16px;
 }


### PR DESCRIPTION
This patch displays the `.button-large` elements (e.g. the new issue button) the same as the other contextual icons.

It works correctly on FF 10, Sefari 5.1 and Chrome 16 on OSX 10.6. It would be great if someone could check it on IE.

This should fix https://www.chiliproject.org/issues/826
