### PR TITLE
Issue option list stacked vertically instead of horizontally (Bug #869)

### DIFF
--- a/app/views/issues/show.rhtml
+++ b/app/views/issues/show.rhtml
@@ -1,5 +1,5 @@
 <div class="title-bar" id="upper-title-bar">
-  <div class="title-bar-actions">
+  <div class="title-bar-extras">
   <%= render :partial => 'action_menu' %>
   </div>
 </div>
@@ -114,7 +114,7 @@
 <div style="clear: both;"></div>
 
 <div class="title-bar" id="lower-title-bar">
-  <div class="title-bar-actions">
+  <div class="title-bar-extras">
     <%= render :partial => 'action_menu', :locals => {:replace_watcher => 'watcher2' } %>
   </div>
 </div>


### PR DESCRIPTION
Replacing class "title-bar-actions" by "title-bar-extras" solves bug #869 "Issue option list stacked vertically instead of horizontally".
