### PR TITLE
861 filter project activities

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -33,7 +33,7 @@ class ActivitiesController < ApplicationController
                                                              :with_subprojects => @with_subprojects,
                                                              :author => @author)
     @activity.scope_select {|t| !params["show_#{t}"].nil?}
-    @activity.scope = (@author.nil? ? :default : :all) if @activity.scope.empty?
+    @activity.scope = (@author.nil? ? :default : :all) if @activity.scope.empty? && !params[:activities_filter]
 
     events = @activity.events(@date_from, @date_to)
 

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -41,6 +41,7 @@
 
 <% content_for :sidebar do %>
 <% form_tag({}, :method => :get) do %>
+<%= hidden_field_tag 'activities_filter', 1 %>
 <h3><%= l(:label_activity) %></h3>
 <p><% @activity.event_types.each do |t| %>
 <%= check_box_tag "show_#{t}", 1, @activity.scope.include?(t) %>


### PR DESCRIPTION
I have added an extra hidden field (activities_filter) on the activity form. 

This way we can see if we have to filter by default values or by the user submission. Else, when the user deselects all checkboxes, he would expect to get an empty search result. 

Since Chiliproject checks default checkboxes on page load, it won't notice that the user has requested an emtpy result set
