### PR TITLE
Standardise JS formatting

### DIFF
--- a/public/javascripts/select_list_move.js
+++ b/public/javascripts/select_list_move.js
@@ -18,7 +18,7 @@ function swapOptions(theSel, index1, index2) {
 
 function deleteOption(theSel, theIndex) {
     var selLength = theSel.length;
-    if(selLength > 0) {
+    if (selLength > 0) {
         theSel.options[theIndex] = null;
     }
 }
@@ -31,7 +31,7 @@ function moveOptions(theSelFrom, theSelTo) {
 
     var i;
 
-    for(i = selLength-1; i >= 0; i--) {
+    for (i = selLength-1; i >= 0; i--) {
         if(theSelFrom.options[i].selected) {
             selectedText[selectedCount] = theSelFrom.options[i].text;
             selectedValues[selectedCount] = theSelFrom.options[i].value;
@@ -40,18 +40,18 @@ function moveOptions(theSelFrom, theSelTo) {
         }
     }
 
-    for(i = selectedCount-1; i >= 0; i--) {
+    for (i = selectedCount-1; i >= 0; i--) {
         addOption(theSelTo, selectedText[i], selectedValues[i]);
     }
 
-    if(NS4) {
+    if (NS4) {
         history.go(0);
     }
 }
 
 function moveOptionUp(theSel) {
     var index = theSel.selectedIndex;
-    if(index > 0) {
+    if (index > 0) {
         swapOptions(theSel, index-1, index);
         theSel.selectedIndex = index-1;
     }
@@ -59,7 +59,7 @@ function moveOptionUp(theSel) {
 
 function moveOptionDown(theSel) {
     var index = theSel.selectedIndex;
-    if(index < theSel.length-1) {
+    if (index < theSel.length-1) {
         swapOptions(theSel, index, index+1);
         theSel.selectedIndex = index+1;
     }
@@ -67,7 +67,7 @@ function moveOptionDown(theSel) {
 
 function selectAllOptions(id) {
     var select = $(id);
-    for(var i = 0; i < select.options.length; i++) {
+    for (var i = 0; i < select.options.length; i++) {
         select.options[i].selected = true;
     }
 }


### PR DESCRIPTION
Pulling this early to get a bit of feedback before attempting to do all the other files.

IMO, library and plugins files shouldn't be reformatted since they shouldn't really be changed directly and ideally the minified versions would be used.

The wiki mentions a bit about indenting but nothing about how functions, for, if should be handled so I'll add some comments along lines in the select_list_move.js file.
