### PR TITLE
Port the JS used to select/reorder issue columns to jQuery.

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -94,7 +94,7 @@ class JournalsController < ApplicationController
       @diff = Redmine::Helpers::Diff.new(to, from)
       @issue = @journal.journaled
       respond_to do |format|
-        format.html { }
+        format.html { render :layout => !request.xhr? }
         format.js { render :layout => false }
       end
     else

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -89,12 +89,12 @@ class Changeset < ActiveRecord::Base
   # Attribute reader for committer that encodes the committer string to
   # the repository log encoding (e.g. UTF-8)
   def committer
-    self.class.to_utf8(read_attribute(:committer), repository.repo_log_encoding)
+    self.class.to_utf8(read_attribute(:committer), repository_encoding)
   end
 
   def before_create
-    self.committer = self.class.to_utf8(self.committer, repository.repo_log_encoding)
-    self.comments  = self.class.normalize_comments(self.comments, repository.repo_log_encoding)
+    self.committer = self.class.to_utf8(self.committer, repository_encoding)
+    self.comments  = self.class.normalize_comments(self.comments, repository_encoding)
     self.user = repository.find_committer_user(self.committer)
   end
 

--- a/app/views/issues/index.rhtml
+++ b/app/views/issues/index.rhtml
@@ -55,13 +55,7 @@
 		</div>
     <p class="buttons hide-when-print">
 
-    <%= link_to_remote l(:button_apply),
-                       { :url => { :set_filter => 1 },
-                         :before => 'selectAllOptions("selected_columns");',
-                         :update => "content",
-                         :complete => "apply_filters_observer()",
-                         :with => "Form.serialize('query_form')"
-                       }, :class => 'icon icon-checked' %>
+    <%= link_to l(:button_apply), '#',  :class => 'icon icon-checked apply' %>
 
     <%= link_to_remote l(:button_clear),
                        { :url => { :set_filter => 1, :project_id => @project },

--- a/app/views/queries/_columns.rhtml
+++ b/app/views/queries/_columns.rhtml
@@ -7,11 +7,10 @@
 		          options_for_select((query.available_columns - query.columns).collect {|column| [column.caption, column.name]}),
 		          :multiple => true, :size => 10, :style => "width:150px" %>
 		</td>
-        <td class="buttons">
-			<input type="button" value="&#8594;"
-			 onclick="moveOptions(this.form.available_columns, this.form.selected_columns);" /><br />
-			<input type="button" value="&#8592;"
-			 onclick="moveOptions(this.form.selected_columns, this.form.available_columns);" />
+        <td class="buttons move">
+			<button type="button" class="add">&#8594;</button>
+			<br />
+			<button type="button" class="remove">&#8592;</button>
 		</td>
 		<td>
                 <%= label_tag "selected_columns", l(:description_selected_columns) %>
@@ -20,9 +19,10 @@
 		          options_for_select(query.columns.collect {|column| [column.caption, column.name]}),
 		          :id => 'selected_columns', :multiple => true, :size => 10, :style => "width:150px" %>
 		</td>
-        <td class="buttons">
-			<input type="button" value="&#8593;" onclick="moveOptionUp(this.form.selected_columns);" /><br />
-			<input type="button" value="&#8595;" onclick="moveOptionDown(this.form.selected_columns);" />
+        <td class="buttons position">
+			<button type="button" class="up">&#8593;</button>
+			<br />
+			<button type="button" class="down">&#8595;</button>
 		</td>
 	</tr>
 </table>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -465,11 +465,8 @@ jQuery.viewportHeight = function() {
         document.body.clientHeight;
 };
 
-// Automatically use format.js for jQuery Ajax
 jQuery.ajaxSetup({
     'beforeSend': function(xhr) {
-        xhr.setRequestHeader("Accept", "text/javascript");
-
         // TODO: Remove once jquery-rails (Rails 3) has been added a dependency
         var csrf_meta_tag = jQuery('meta[name="csrf-token"]');
         if (csrf_meta_tag) {

--- a/public/javascripts/select_list_move.js
+++ b/public/javascripts/select_list_move.js
@@ -1,31 +1,33 @@
 (function($) {
-    $(document).ready(function() {
-        var moveButtons = $('.query-columns .buttons.move');
-        var positionButtons = $('.query-columns .buttons.position');
+    $(function() {
+        var avaliableColumns = '#available_columns';
+        var selectedColumns = '#selected_columns';
+        var queryForm = '#query_form';
+        var main = $('#main');
 
-        var avaliableColumns = $('#available_columns');
-        var selectedColumns = $('#selected_columns');
-
-        moveButtons.find('.add').on('click', function() {
+        main.on('click', queryForm + ' .add', function() {
             moveOptions(avaliableColumns, selectedColumns);
         });
-        moveButtons.find('.remove').on('click', function() {
+        main.on('click', queryForm + ' .remove', function() {
             moveOptions(selectedColumns, avaliableColumns);
         });
 
-        positionButtons.find('.up').on('click', function() {
+        main.on('click', queryForm + ' .up', function() {
             changeOptionPosition(selectedColumns, 0);
         });
-        positionButtons.find('.down').on('click', function() {
+        main.on('click', queryForm + ' .down', function() {
             changeOptionPosition(selectedColumns, 1);
         });
 
         function moveOptions(theSelFrom, theSelTo) {
+            theSelFrom = $(theSelFrom);
+            theSelTo = $(theSelTo);
             selectedOptions = theSelFrom.find('option:selected');
-            selectedOptions.appendTo(theSelTo);
+            selectedOptions.appendTo(theSelTo).attr('selected', false);
         }
 
         function changeOptionPosition(theSelForm, direction) {
+            theSelForm = $(theSelForm);
             var selectedItems = theSelForm.find('option:selected');
             if(direction === 1) {
                 selectedItems = $(selectedItems.get().reverse());

--- a/public/javascripts/select_list_move.js
+++ b/public/javascripts/select_list_move.js
@@ -1,82 +1,48 @@
-var NS4 = (navigator.appName == "Netscape" && parseInt(navigator.appVersion) < 5);
+(function($) {
+    $(document).ready(function() {
+        var moveButtons = $('.query-columns .buttons.move');
+        var positionButtons = $('.query-columns .buttons.position');
 
-function addOption(theSel, theText, theValue)
-{
-  var newOpt = new Option(theText, theValue);
-  var selLength = theSel.length;
-  theSel.options[selLength] = newOpt;
-}
+        var avaliableColumns = $('#available_columns');
+        var selectedColumns = $('#selected_columns');
 
-function swapOptions(theSel, index1, index2)
-{
-	var text, value;
-  text = theSel.options[index1].text;
-  value = theSel.options[index1].value;
-  theSel.options[index1].text = theSel.options[index2].text;
-  theSel.options[index1].value = theSel.options[index2].value;
-  theSel.options[index2].text = text;
-  theSel.options[index2].value = value;
-}
+        moveButtons.find('.add').on('click', function() {
+            moveOptions(avaliableColumns, selectedColumns);
+        });
+        moveButtons.find('.remove').on('click', function() {
+            moveOptions(selectedColumns, avaliableColumns);
+        });
 
-function deleteOption(theSel, theIndex)
-{ 
-  var selLength = theSel.length;
-  if(selLength>0)
-  {
-    theSel.options[theIndex] = null;
-  }
-}
+        positionButtons.find('.up').on('click', function() {
+            changeOptionPosition(selectedColumns, 0);
+        });
+        positionButtons.find('.down').on('click', function() {
+            changeOptionPosition(selectedColumns, 1);
+        });
 
-function moveOptions(theSelFrom, theSelTo)
-{
-  
-  var selLength = theSelFrom.length;
-  var selectedText = new Array();
-  var selectedValues = new Array();
-  var selectedCount = 0;
-  
-  var i;
-  
-  for(i=selLength-1; i>=0; i--)
-  {
-    if(theSelFrom.options[i].selected)
-    {
-      selectedText[selectedCount] = theSelFrom.options[i].text;
-      selectedValues[selectedCount] = theSelFrom.options[i].value;
-      deleteOption(theSelFrom, i);
-      selectedCount++;
-    }
-  }
-  
-  for(i=selectedCount-1; i>=0; i--)
-  {
-    addOption(theSelTo, selectedText[i], selectedValues[i]);
-  }
-  
-  if(NS4) history.go(0);
-}
+        function moveOptions(theSelFrom, theSelTo) {
+            selectedOptions = theSelFrom.find('option:selected');
+            selectedOptions.appendTo(theSelTo);
+        }
 
-function moveOptionUp(theSel) {
-	var index = theSel.selectedIndex;
-	if (index > 0) {
-		swapOptions(theSel, index-1, index);
-  	theSel.selectedIndex = index-1;
-	}
-}
+        function changeOptionPosition(theSelForm, direction) {
+            var selectedItems = theSelForm.find('option:selected');
+            if(direction === 1) {
+                selectedItems = $(selectedItems.get().reverse());
+            }
 
-function moveOptionDown(theSel) {
-	var index = theSel.selectedIndex;
-	if (index < theSel.length - 1) {
-		swapOptions(theSel, index, index+1);
-  	theSel.selectedIndex = index+1;
-	}
-}
-
-function selectAllOptions(id)
-{
-  var select = $(id);
-  for (var i=0; i<select.options.length; i++) {
-    select.options[i].selected = true;
-  }
-}
-
+            selectedItems.each(function() {
+                var self = $(this);
+                if(direction === 0) {
+                    if(self.prev('option').is(':selected') === false) {
+                        self.prev('option').before(self);
+                    }
+                } else {
+                    if(self.next('option').is(':selected') === false) {
+                        self.next('option').after(self);
+                    }
+                }
+            });
+        }
+    });
+})(jQuery);

--- a/public/javascripts/select_list_move.js
+++ b/public/javascripts/select_list_move.js
@@ -19,6 +19,24 @@
             changeOptionPosition(selectedColumns, 1);
         });
 
+        main.on('click', queryForm + ' .apply', function(e) {
+            e.preventDefault();
+            selectAllOptions(selectedColumns);
+
+            var data = $(queryForm).serializeArray();
+            var url = jQuery('form[action*="issues"]').attr('action');
+            $.ajax({
+                url: url + '?set_filter=1',
+                data: data,
+                type: 'GET',
+                dataType: 'html',
+                success: function(response) {
+                    $('#content').html(response);
+                    apply_filters_observer();
+                }
+            });
+        });
+
         function moveOptions(theSelFrom, theSelTo) {
             theSelFrom = $(theSelFrom);
             theSelTo = $(theSelTo);
@@ -45,6 +63,10 @@
                     }
                 }
             });
+        }
+
+        function selectAllOptions(id) {
+            $(id + ' option').attr('selected', true);
         }
     });
 })(jQuery);

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -666,7 +666,6 @@ table.query-columns {
 
 table.query-columns td.buttons {
   vertical-align: middle;
-  text-align: center;
 }
 
 td.center {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1889,6 +1889,10 @@ div.autocomplete ul li span.informal {
   width: 500px;
 }
 
+.ui-autocomplete a {
+  font-weight: normal;
+}
+
 /***** Diff *****/
 .diff_out {
   background: #fcc;


### PR DESCRIPTION
This rewrites the JS used to add/remove columns and reorder them on the issue page.
Instead of using inline 'onclick' attributes it uses jQuery document ready function to add the click handlers.

The <input type="button" /> were replaced with <button> tags. Because of that change a minor CSS change as needed to align the buttons correctly.

Remote issue - https://www.chiliproject.org/issues/948
