### PR TITLE
[#949] Port the repository navigation JS to jQuery

### DIFF
--- a/public/javascripts/repository_navigation.js
+++ b/public/javascripts/repository_navigation.js
@@ -1,35 +1,36 @@
-Event.observe(window,'load',function() {
-  /* 
-  If we're viewing a tag or branch, don't display it in the
-  revision box
-  */
-  var branch_selected = $('branch') && $('rev').getValue() == $('branch').getValue();
-  var tag_selected = $('tag') && $('rev').getValue() == $('tag').getValue();
-  if (branch_selected || tag_selected) {
-    $('rev').setValue('');
-  }
+(function($) {
+    $(document).ready(function() {
+        var branchSelect = $('#branch');
+        var tagSelect = $('#tag');
+        var branchAndTag = branchSelect.add(tagSelect);
+        var revInput = $('#rev');
+        var isBranchSelected = branchSelect && revInput.val() === branchSelect.val();
+        var isTagSelected = tagSelect && revInput.val() === tagSelect.val();
 
-  /* 
-  Copy the branch/tag value into the revision box, then disable
-  the dropdowns before submitting the form
-  */
-  $$('#branch,#tag').each(function(e) {
-    e.observe('change',function(e) {
-      $('rev').setValue(e.element().getValue());
-      $$('#branch,#tag').invoke('disable');
-      e.element().parentNode.submit();
-      $$('#branch,#tag').invoke('enable');
+        // If we're viewing a tag or branch, don't display it in the revision
+        // box
+        if (isBranchSelected || isTagSelected) {
+            revInput.val('');
+        }
+
+        // Copy the branch/tag value into the revision box, then disable the 
+        // dropdowns before submitting the form
+        branchAndTag.on('change', function() {
+            var self = $(this);
+            revInput.val(self.val());
+            branchAndTag.attr('disabled', 'disabled');
+            self.parents('form').submit();
+        });
+
+        // Submit the form when the enter key is pressed in the revision box
+        // after disabling the select boxes
+        revInput.on('keydown', function(e) {
+            var self = $(this);
+            if(e.keyCode === 13) {
+                branchAndTag.attr('disabled', 'disabled');
+                self.parents('form').submit();
+            }
+        });
     });
-  });
+})(jQuery);
 
-  /*
-  Disable the branch/tag dropdowns before submitting the revision form
-  */
-  $('rev').observe('keydown', function(e) {
-    if (e.keyCode == 13) {
-      $$('#branch,#tag').invoke('disable');
-      e.element().parentNode.submit();
-      $$('#branch,#tag').invoke('enable');
-    }
-  });
-})


### PR DESCRIPTION
The original version disabled and then instantly re-enabled the select boxes when submitting the form. I assumed that was an error so didn't copy that over. If it's not an error, what's the point in the code? Could the disable be removed as well?

Remote issue - https://www.chiliproject.org/issues/949
