### PR TITLE
Set the X-CSRF-Token header for AJAX requests with jQuery.

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -467,7 +467,15 @@ jQuery.viewportHeight = function() {
 
 // Automatically use format.js for jQuery Ajax
 jQuery.ajaxSetup({
-  'beforeSend': function(xhr) {xhr.setRequestHeader("Accept", "text/javascript")}
+    'beforeSend': function(xhr) {
+        xhr.setRequestHeader("Accept", "text/javascript");
+
+        // TODO: Remove once jquery-rails has been added a dependency
+        var csrf_meta_tag = jQuery('meta[name="csrf-token"]');
+        if (csrf_meta_tag) {
+            xhr.setRequestHeader('X-CSRF-Token', csrf_meta_tag.attr('content'));
+        }
+    }
 })
 
 /* TODO: integrate with existing code and/or refactor */


### PR DESCRIPTION
jQuery AJAX calls weren't setting the CSRF value in the header. Currently this shouldn't be a problem but when jQuery replaces Prototype it will need to be included.

Remove issue - https://www.chiliproject.org/issues/950
