### PR TITLE
Fixes Issue 975 - Validate and enable editing of Version start date

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -27,6 +27,7 @@ class Version < ActiveRecord::Base
   validates_presence_of :name
   validates_uniqueness_of :name, :scope => [:project_id]
   validates_length_of :name, :maximum => 60
+  validates_format_of :start_date, :with => /^\d{4}-\d{2}-\d{2}$/, :message => :not_a_date, :allow_nil => true
   validates_format_of :effective_date, :with => /^\d{4}-\d{2}-\d{2}$/, :message => :not_a_date, :allow_nil => true
   validates_inclusion_of :status, :in => VERSION_STATUSES
   validates_inclusion_of :sharing, :in => VERSION_SHARINGS
@@ -37,6 +38,7 @@ class Version < ActiveRecord::Base
 
   safe_attributes 'name',
     'description',
+    'start_date',
     'effective_date',
     'due_date',
     'wiki_page_title',


### PR DESCRIPTION
When creating or updating a version, the Start Date is not saved (however the End Date is). If you update the Start Date manually in the DB, it will display the correct date, but it is still unchangeable. 

https://www.chiliproject.org/issues/975
