### PR TITLE
Added fast hack to resolve project menu height problem

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -564,6 +564,12 @@ jQuery(document).ready(function($) {
   $('#account-nav .drop-down').live('click', function(event) {
     var menuItem = $(this);
 
+    var windowHeight = Math.floor($.viewportHeight() * 0.8);
+    if(menuItem.find("ul").height() > $.viewportHeight())
+    {
+      menuItem.find("ul").css({'height':windowHeight, 'overflow-y':'scroll'});
+    }
+
     toggleTopMenu(menuItem);
 
     if (menuItem.hasClass('open')) {


### PR DESCRIPTION
I have about 150 projects in Chiliproject. As it is right now, the project menu (upper selector button) is about 5 times the actual page height. With the little piece of JS the height is set to 80% of the window height, but only if the menu height is greater then the page height. Then it adds a scrollbar to the menu.
