### PR TITLE
The change fixes a serious vulnerability in the git repository code

### DIFF
--- a/lib/redmine/scm/adapters/git_adapter.rb
+++ b/lib/redmine/scm/adapters/git_adapter.rb
@@ -340,6 +340,9 @@ module Redmine
         end
 
         def scm_cmd(*args, &block)
+          args.each do |a|
+            a.gsub!([^\.\-\w_\:]/, '')
+          end
           repo_path = root_url || url
           full_args = [GIT_BIN, '--git-dir', repo_path]
           if self.class.client_version_above?([1, 7, 2])


### PR DESCRIPTION
The vulnerability can be exposed by using this URL:
http://CHILIHOST/projects/MYPROJECT/repository/changes?git_url_text=&branch=master&rev=master||echo+AAA+>/tmp/aa.txt &

The code can create files as the git user running chiliproject.
