### PR TITLE
Scm refactoring

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -118,41 +118,47 @@ class RepositoriesController < ApplicationController
     # If the entry is a dir, show the browser
     (show; return) if @entry.is_dir?
 
-    @content = @repository.cat(@path, @rev)
-    (show_error_not_found; return) unless @content
-    if 'raw' == params[:format] ||
-         (@content.size && @content.size > Setting.file_max_size_displayed.to_i.kilobyte) ||
-         ! is_entry_text_data?(@content, @path)
-      # Force the download
-      send_opt = { :filename => filename_for_content_disposition(@path.split('/').last) }
-      send_type = Redmine::MimeType.of(@path)
-      send_opt[:type] = send_type.to_s if send_type
-      send_data @content, send_opt
-    else
-      # Prevent empty lines when displaying a file with Windows style eol
-      # TODO: UTF-16
-      # Is this needs? AttachmentsController reads file simply.
-      @content.gsub!("\r\n", "\n")
-      @changeset = @repository.find_changeset_by_name(@rev)
+    @repository.cat_to_tempfile(@path, @rev) do |f|
+      if params[:format] == 'raw' || is_too_large_to_show?(f) || is_binary?(f, @path)
+        send_type = Redmine::MimeType.of(@path)
+        options = {
+          :filename    => filename_for_content_disposition(@path.split('/').last),
+          :disposition => 'attachment',
+          :x_sendfile  => false # x_sendfile does not work well with tempfiles
+        }
+        options[:type] = send_type.to_s if send_type
+        send_file(f.path, options)
+      else
+        f.rewind
+        @content = f.read
+        @changeset = @repository.find_changeset_by_name(@rev)
+      end
     end
   end
 
-  def is_entry_text_data?(ent, path)
-    # UTF-16 contains "\x00".
-    # It is very strict that file contains less than 30% of ascii symbols
-    # in non Western Europe.
-    return true if Redmine::MimeType.is_type?('text', path)
-    # Ruby 1.8.6 has a bug of integer divisions.
-    # http://apidock.com/ruby/v1_8_6_287/String/is_binary_data%3F
-    if ent.respond_to?("is_binary_data?") && ent.is_binary_data? # Ruby 1.8.x and <1.9.2
-      return false
-    elsif ent.respond_to?(:force_encoding) && (ent.dup.force_encoding("UTF-8") != ent.dup.force_encoding("BINARY") ) # Ruby 1.9.2
-      # TODO: need to handle edge cases of non-binary content that isn't UTF-8
-      return false
-    end
-    true
+  def is_too_large_to_show?(f)
+    f.size > Setting.file_max_size_displayed.to_i.kilobyte
   end
-  private :is_entry_text_data?
+  private :is_too_large_to_show?
+
+  def is_binary?(file, path)
+
+    return false if Redmine::MimeType.is_type?('text', path)
+
+    # First block of the file is examined for odd
+    # characters such as strange control codes or char-
+    # acters with the high bit set.  If too many strange
+    # characters (>30%) are found, it's a binary file,
+    # otherwise it's a text file.  Also, any file con-
+    # taining null in the first block is considered a
+    # binary file.
+
+    blk = file.read(Setting.file_max_size_displayed.to_i.kilobyte)
+    return blk.size == 0 ||
+           blk.count("^ -~", "^\r\n") / blk.size > 0.3 ||
+           blk.count("\x00") > 0
+  end
+  private :is_binary?
 
   def annotate
     @entry = @repository.entry(@path, @rev)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -104,6 +104,10 @@ class Repository < ActiveRecord::Base
     scm.cat(path, identifier)
   end
 
+  def cat_to_tempfile(path, identifier, &block)
+    scm.cat_to_tempfile(path, identifier, &block)
+  end
+
   def diff(path, rev, rev_to)
     scm.diff(path, rev, rev_to)
   end

--- a/app/models/repository/cvs.rb
+++ b/app/models/repository/cvs.rb
@@ -66,6 +66,11 @@ class Repository::Cvs < Repository
     scm.cat(path, rev.nil? ? nil : rev.committed_on)
   end
 
+  def cat_to_tempfile(path, identifier, &block)
+    rev = changesets.find_by_revision(identifier)
+    scm.cat_to_tempfile(path, rev.nil? ? nil : rev.committed_on, &block)
+  end
+
   def diff(path, rev, rev_to)
     #convert rev to revision. CVS can't handle changesets here
     diff=[]

--- a/lib/redmine/scm/adapters/filesystem_adapter.rb
+++ b/lib/redmine/scm/adapters/filesystem_adapter.rb
@@ -85,10 +85,20 @@ module Redmine
 
         def cat(path, identifier=nil)
           p = scm_iconv(@path_encoding, 'UTF-8', target(path))
-          File.new(p, "rb").read
+          src = File.new(p, "rb")
+          ret = src.read
+          src.close
+          ret
         rescue  => err
           logger.error "scm: filesystem: error: #{err.message}"
           raise CommandFailed.new(err.message)
+        end
+
+        def save_entry_in_file(dest, path, identifier)
+          p = scm_iconv(@path_encoding, 'UTF-8', target(path))
+          src = File.new(p, "rb")
+          FileUtils.copy_stream(src, dest)
+          src.close
         end
 
         private

--- a/lib/redmine/scm/adapters/git_adapter.rb
+++ b/lib/redmine/scm/adapters/git_adapter.rb
@@ -142,7 +142,7 @@ module Redmine
           return nil if path.nil?
           cmd_args = %w|log --no-color --encoding=UTF-8 --date=iso --pretty=fuller --no-merges -n 1|
           cmd_args << rev if rev
-          cmd_args << "--" << path unless path.empty?
+          cmd_args << "--" << scm_iconv(@path_encoding, 'UTF-8', path) if path.present?
           lines = []
           scm_cmd(*cmd_args) { |io| lines = io.readlines }
           begin
@@ -177,7 +177,7 @@ module Redmine
           from_to << "#{identifier_to}" if identifier_to
           cmd_args << from_to if !from_to.empty?
           cmd_args << "--since='#{options[:since].strftime("%Y-%m-%d %H:%M:%S")}'" if options[:since]
-          cmd_args << "--" << scm_iconv(@path_encoding, 'UTF-8', path) if path && !path.empty?
+          cmd_args << "--" << scm_iconv(@path_encoding, 'UTF-8', path) if path.present?
 
           scm_cmd *cmd_args do |io|
             files=[]
@@ -269,7 +269,7 @@ module Redmine
           else
             cmd_args << "show" << "--no-color" << identifier_from
           end
-          cmd_args << "--" <<  scm_iconv(@path_encoding, 'UTF-8', path) unless path.empty?
+          cmd_args << "--" << scm_iconv(@path_encoding, 'UTF-8', path) if path.present?
           diff = []
           scm_cmd *cmd_args do |io|
             io.each_line do |line|

--- a/lib/redmine/scm/adapters/mercurial_adapter.rb
+++ b/lib/redmine/scm/adapters/mercurial_adapter.rb
@@ -27,9 +27,6 @@ module Redmine
         TEMPLATE_NAME = "hg-template"
         TEMPLATE_EXTENSION = "tmpl"
 
-        # raised if hg command exited with error, e.g. unknown revision.
-        class HgCommandAborted < CommandFailed; end
-
         class << self
           def client_command
             @@bin    ||= HG_BIN
@@ -51,10 +48,7 @@ module Redmine
             # The hg version is expressed either as a
             # release number (eg 0.9.5 or 1.0) or as a revision
             # id composed of 12 hexa characters.
-            theversion = hgversion_from_command_line.dup
-            if theversion.respond_to?(:force_encoding)
-              theversion.force_encoding('ASCII-8BIT')
-            end
+            theversion = to_ascii(hgversion_from_command_line.dup)
             if m = theversion.match(%r{\A(.*?)((\d+\.)+\d+)})
               m[2].scan(%r{\d+}).collect(&:to_i)
             end
@@ -114,56 +108,43 @@ module Redmine
           Hash[*alist.flatten]
         end
 
-        def summary
-          return @summary if @summary
-          hg 'rhsummary' do |io|
-            output = io.read
-            if output.respond_to?(:force_encoding)
-              output.force_encoding('UTF-8')
-            end
-            begin
-              @summary = ActiveSupport::XmlMini.parse(output)['rhsummary']
-            rescue
-            end
-          end
-        end
-        private :summary
 
         def entries(path=nil, identifier=nil)
           p1 = scm_iconv(@path_encoding, 'UTF-8', path)
-          manifest = hg('rhmanifest', '-r', CGI.escape(hgrev(identifier)),
-                        CGI.escape(without_leading_slash(p1.to_s))) do |io|
-            output = io.read
-            if output.respond_to?(:force_encoding)
-              output.force_encoding('UTF-8')
+          cmd_args = [
+            'rhmanifest',
+            '-r',
+            CGI.escape(hgrev(identifier)),
+            CGI.escape(without_leading_slash(p1.to_s))
+          ]
+
+          manifest = scm_cmd cmd_args do |io|
+            output = to_utf8(io.read)
+            ActiveSupport::XmlMini.parse(output)['rhmanifest']['repository']['manifest']
+          end
+
+          if manifest
+            path_prefix = path.blank? ? '' : with_trailling_slash(path)
+
+            entries = Entries.new
+            as_ary(manifest['dir']).each do |e|
+              n = unescape(e['name'])
+              p = "#{path_prefix}#{n}"
+              entries << Entry.new(:name => n, :path => p, :kind => 'dir')
             end
-            begin
-              ActiveSupport::XmlMini.parse(output)['rhmanifest']['repository']['manifest']
-            rescue
+
+            as_ary(manifest['file']).each do |e|
+              n = unescape(e['name'])
+              p = "#{path_prefix}#{n}"
+              lr = Revision.new(:revision => e['revision'], :scmid => e['node'],
+                                :identifier => e['node'],
+                                :time => Time.at(e['time'].to_i))
+              entries << Entry.new(:name => n, :path => p, :kind => 'file',
+                                   :size => e['size'].to_i, :lastrev => lr)
             end
-          end
-          path_prefix = path.blank? ? '' : with_trailling_slash(path)
 
-          entries = Entries.new
-          as_ary(manifest['dir']).each do |e|
-            n = scm_iconv('UTF-8', @path_encoding, CGI.unescape(e['name']))
-            p = "#{path_prefix}#{n}"
-            entries << Entry.new(:name => n, :path => p, :kind => 'dir')
+            entries
           end
-
-          as_ary(manifest['file']).each do |e|
-            n = scm_iconv('UTF-8', @path_encoding, CGI.unescape(e['name']))
-            p = "#{path_prefix}#{n}"
-            lr = Revision.new(:revision => e['revision'], :scmid => e['node'],
-                              :identifier => e['node'],
-                              :time => Time.at(e['time'].to_i))
-            entries << Entry.new(:name => n, :path => p, :kind => 'file',
-                                 :size => e['size'].to_i, :lastrev => lr)
-          end
-
-          entries
-        rescue HgCommandAborted
-          nil  # means not found
         end
 
         def revisions(path=nil, identifier_from=nil, identifier_to=nil, options={})
@@ -175,103 +156,106 @@ module Redmine
         # Iterates the revisions by using a template file that
         # makes Mercurial produce a xml output.
         def each_revision(path=nil, identifier_from=nil, identifier_to=nil, options={})
-          hg_args = ['log', '--debug', '-C', '--style', self.class.template_path]
-          hg_args << '-r' << "#{hgrev(identifier_from)}:#{hgrev(identifier_to)}"
-          hg_args << '--limit' << options[:limit] if options[:limit]
-          hg_args << hgtarget(path) unless path.blank?
-          log = hg(*hg_args) do |io|
+          cmd_args = ['log', '--debug', '-C', '--style', self.class.template_path]
+          cmd_args << '-r' << "#{hgrev(identifier_from)}:#{hgrev(identifier_to)}"
+          cmd_args << '--limit' << options[:limit] if options[:limit]
+          cmd_args << hgtarget(path) unless path.blank?
+
+          log = scm_cmd(cmd_args) do |io|
             output = io.read
             if output.respond_to?(:force_encoding)
               output.force_encoding('UTF-8')
             end
-            begin
-              # Mercurial < 1.5 does not support footer template for '</log>'
-              ActiveSupport::XmlMini.parse("#{output}</log>")['log']
-            rescue
-            end
+            ActiveSupport::XmlMini.parse("#{output}</log>")['log']
           end
 
-          as_ary(log['logentry']).each do |le|
-            cpalist = as_ary(le['paths']['path-copied']).map do |e|
-              [e['__content__'], e['copyfrom-path']].map do |s|
-                scm_iconv('UTF-8', @path_encoding, CGI.unescape(s))
+          if log
+            as_ary(log['logentry']).each do |le|
+              cpalist = as_ary(le['paths']['path-copied']).map do |e|
+                [e['__content__'], e['copyfrom-path']].map do |s|
+                  unescape s
+                end
               end
+              cpmap = Hash[*cpalist.flatten]
+
+              paths = as_ary(le['paths']['path']).map do |e|
+                p = unescape e['__content__']
+                {:action => e['action'], :path => with_leading_slash(p),
+                 :from_path => (cpmap.member?(p) ? with_leading_slash(cpmap[p]) : nil),
+                 :from_revision => (cpmap.member?(p) ? le['revision'] : nil)}
+              end.sort { |a, b| a[:path] <=> b[:path] }
+
+              yield Revision.new(:revision => le['revision'],
+                                 :scmid => le['node'],
+                                 :author => (le['author']['__content__'] rescue ''),
+                                 :time => Time.parse(le['date']['__content__']),
+                                 :message => le['msg']['__content__'],
+                                 :paths => paths)
             end
-            cpmap = Hash[*cpalist.flatten]
-
-            paths = as_ary(le['paths']['path']).map do |e|
-              p = scm_iconv('UTF-8', @path_encoding, CGI.unescape(e['__content__']) )
-              {:action => e['action'], :path => with_leading_slash(p),
-               :from_path => (cpmap.member?(p) ? with_leading_slash(cpmap[p]) : nil),
-               :from_revision => (cpmap.member?(p) ? le['revision'] : nil)}
-            end.sort { |a, b| a[:path] <=> b[:path] }
-
-            yield Revision.new(:revision => le['revision'],
-                               :scmid => le['node'],
-                               :author => (le['author']['__content__'] rescue ''),
-                               :time => Time.parse(le['date']['__content__']),
-                               :message => le['msg']['__content__'],
-                               :paths => paths)
+            self
           end
-          self
         end
 
         # Returns list of nodes in the specified branch
         def nodes_in_branch(branch, options={})
-          hg_args = ['rhlog', '--template', '{node|short}\n', '--rhbranch', CGI.escape(branch)]
-          hg_args << '--from' << CGI.escape(branch)
-          hg_args << '--to'   << '0'
-          hg_args << '--limit' << options[:limit] if options[:limit]
-          hg(*hg_args) { |io| io.readlines.map { |e| e.chomp } }
+          cmd_args = ['rhlog', '--template', '{node|short}\n', '--rhbranch', CGI.escape(branch)]
+          cmd_args << '--from' << CGI.escape(branch)
+          cmd_args << '--to'   << '0'
+          cmd_args << '--limit' << options[:limit] if options[:limit]
+          scm_cmd(cmd_args) do |io|
+            io.readlines.map { |e| e.chomp }
+          end
         end
 
         def diff(path, identifier_from, identifier_to=nil)
-          hg_args = %w|rhdiff|
+          cmd_args = %w|rhdiff|
           if identifier_to
-            hg_args << '-r' << hgrev(identifier_to) << '-r' << hgrev(identifier_from)
+            cmd_args << '-r' << hgrev(identifier_to) << '-r' << hgrev(identifier_from)
           else
-            hg_args << '-c' << hgrev(identifier_from)
+            cmd_args << '-c' << hgrev(identifier_from)
           end
           unless path.blank?
             p = scm_iconv(@path_encoding, 'UTF-8', path)
-            hg_args << CGI.escape(hgtarget(p))
+            cmd_args << CGI.escape(hgtarget(p))
           end
-          diff = []
-          hg *hg_args do |io|
-            io.each_line do |line|
-              diff << line
-            end
+          scm_cmd cmd_args do |io|
+            diff = []
+            io.each_line{ |line| diff << line }
+            diff
           end
-          diff
-        rescue HgCommandAborted
-          nil  # means not found
         end
 
         def cat(path, identifier=nil)
-          p = CGI.escape(scm_iconv(@path_encoding, 'UTF-8', path))
-          hg 'rhcat', '-r', CGI.escape(hgrev(identifier)), hgtarget(p) do |io|
+          p = escape(path)
+          cmd_args = ['rhcat', '-r', CGI.escape(hgrev(identifier)), hgtarget(p)]
+          scm_cmd cmd_args do |io|
             io.binmode
             io.read
           end
-        rescue HgCommandAborted
-          nil  # means not found
+        end
+
+        def save_entry_in_file(f, path, identifier)
+          p = escape(path)
+          cmd_args = ['rhcat', '-r', CGI.escape(hgrev(identifier)), hgtarget(p)]
+          scm_cmd(cmd_args, f.path)
         end
 
         def annotate(path, identifier=nil)
-          p = CGI.escape(scm_iconv(@path_encoding, 'UTF-8', path))
-          blame = Annotate.new
-          hg 'rhannotate', '-ncu', '-r', CGI.escape(hgrev(identifier)), hgtarget(p) do |io|
+          p = escape(path)
+          cmd_args = ['rhannotate', '-ncu', '-r', CGI.escape(hgrev(identifier)), hgtarget(p)]
+          scm_cmd cmd_args do |io|
+            blame = Annotate.new
+
             io.each_line do |line|
-              line.force_encoding('ASCII-8BIT') if line.respond_to?(:force_encoding)
+              to_ascii(line)
               next unless line =~ %r{^([^:]+)\s(\d+)\s([0-9a-f]+):\s(.*)$}
               r = Revision.new(:author => $1.strip, :revision => $2, :scmid => $3,
                                :identifier => $3)
               blame.add_line($4.rstrip, r)
             end
+
+            blame
           end
-          blame
-        rescue HgCommandAborted
-          nil  # means not found or cannot be annotated
         end
 
         class Revision < Redmine::Scm::Adapters::Revision
@@ -281,20 +265,16 @@ module Redmine
           end
         end
 
-        # Runs 'hg' command with the given args
-        def hg(*args, &block)
+        private
+
+        def build_scm_cmd(args)
           repo_path = root_url || url
           full_args = [HG_BIN, '-R', repo_path, '--encoding', 'utf-8']
           full_args << '--config' << "extensions.redminehelper=#{HG_HELPER_EXT}"
           full_args << '--config' << 'diff.git=false'
           full_args += args
-          ret = shellout(full_args.map { |e| shell_quote e.to_s }.join(' '), &block)
-          if $? && $?.exitstatus != 0
-            raise HgCommandAborted, "hg exited with non-zero status: #{$?.exitstatus}"
-          end
-          ret
+          full_args.map { |e| shell_quote e.to_s }.join(' ')
         end
-        private :hg
 
         # Returns correct revision identifier
         def hgrev(identifier, sq=false)
@@ -302,19 +282,47 @@ module Redmine
           rev = shell_quote(rev) if sq
           rev
         end
-        private :hgrev
 
         def hgtarget(path)
           path ||= ''
           root_url + '/' + without_leading_slash(path)
         end
-        private :hgtarget
 
         def as_ary(o)
           return [] unless o
           o.is_a?(Array) ? o : Array[o]
         end
-        private :as_ary
+
+        def summary
+          return @summary if @summary
+          scm_cmd ['rhsummary'] do |io|
+            output = to_utf8(io.read)
+            @summary = ActiveSupport::XmlMini.parse(output)['rhsummary']
+          end
+        end
+
+        def to_utf8(str)
+          str.force_encoding('UTF-8') if str.respond_to?(:force_encoding)
+          str
+        end
+
+        def self.to_ascii(str)
+          str.force_encoding('ASCII-8BIT') if str.respond_to?(:force_encoding)
+          str
+        end
+
+        def to_ascii(str)
+          self.class.to_ascii(str)
+        end
+
+        def escape(str)
+          CGI.escape(scm_iconv(@path_encoding, 'UTF-8', str))
+        end
+
+        def unescape(str)
+          scm_iconv('UTF-8', @path_encoding, CGI.unescape(str))
+        end
+
       end
     end
   end

--- a/lib/redmine/scm/adapters/subversion_adapter.rb
+++ b/lib/redmine/scm/adapters/subversion_adapter.rb
@@ -51,199 +51,183 @@ module Redmine
           end
 
           def scm_version_from_command_line
-            shellout("#{sq_bin} --version") { |io| io.read }.to_s
+            shellout("#{sq_bin} --version"){ |io| io.read }.to_s
           end
         end
 
         # Get info about the svn repository
         def info
-          cmd = "#{self.class.sq_bin} info --xml #{target}"
-          cmd << credentials_string
-          info = nil
-          shellout(cmd) do |io|
+          cmd_args = ['info','--xml', target, credentials_string]
+          scm_cmd(cmd_args) do |io|
             output = io.read
             if output.respond_to?(:force_encoding)
               output.force_encoding('UTF-8')
             end
-            begin
-              doc = ActiveSupport::XmlMini.parse(output)
-              #root_url = doc.elements["info/entry/repository/root"].text
-              info = Info.new({:root_url => doc['info']['entry']['repository']['root']['__content__'],
-                               :lastrev => Revision.new({
-                                 :identifier => doc['info']['entry']['commit']['revision'],
-                                 :time => Time.parse(doc['info']['entry']['commit']['date']['__content__']).localtime,
-                                 :author => (doc['info']['entry']['commit']['author'] ? doc['info']['entry']['commit']['author']['__content__'] : "")
-                               })
-                             })
-            rescue
-            end
+            doc = ActiveSupport::XmlMini.parse(output)
+            #root_url = doc.elements["info/entry/repository/root"].text
+            Info.new({
+              :root_url => doc['info']['entry']['repository']['root']['__content__'],
+              :lastrev => Revision.new({
+                :identifier => doc['info']['entry']['commit']['revision'],
+                :time => Time.parse(doc['info']['entry']['commit']['date']['__content__']).localtime,
+                :author => (doc['info']['entry']['commit']['author'] ? doc['info']['entry']['commit']['author']['__content__'] : "")
+              })
+            })
           end
-          return nil if $? && $?.exitstatus != 0
-          info
-        rescue CommandFailed
-          return nil
         end
 
         # Returns an Entries collection
         # or nil if the given path doesn't exist in the repository
         def entries(path=nil, identifier=nil)
           path ||= ''
-          identifier = (identifier and identifier.to_i > 0) ? identifier.to_i : "HEAD"
+          identifier = initialize_identifier(identifier)
           entries = Entries.new
-          cmd = "#{self.class.sq_bin} list --xml #{target(path)}@#{identifier}"
-          cmd << credentials_string
-          shellout(cmd) do |io|
+          cmd_args = ['list', '--xml', "#{target(path)}@#{identifier}", credentials_string]
+          scm_cmd(cmd_args) do |io|
             output = io.read
             if output.respond_to?(:force_encoding)
               output.force_encoding('UTF-8')
             end
-            begin
-              doc = ActiveSupport::XmlMini.parse(output)
-              each_xml_element(doc['lists']['list'], 'entry') do |entry|
-                commit = entry['commit']
-                commit_date = commit['date']
-                # Skip directory if there is no commit date (usually that
-                # means that we don't have read access to it)
-                next if entry['kind'] == 'dir' && commit_date.nil?
-                name = entry['name']['__content__']
-                entries << Entry.new({:name => URI.unescape(name),
-                            :path => ((path.empty? ? "" : "#{path}/") + name),
-                            :kind => entry['kind'],
-                            :size => ((s = entry['size']) ? s['__content__'].to_i : nil),
-                            :lastrev => Revision.new({
-                              :identifier => commit['revision'],
-                              :time => Time.parse(commit_date['__content__'].to_s).localtime,
-                              :author => ((a = commit['author']) ? a['__content__'] : nil)
-                              })
+            doc = ActiveSupport::XmlMini.parse(output)
+            each_xml_element(doc['lists']['list'], 'entry') do |entry|
+              commit = entry['commit']
+              commit_date = commit['date']
+              # Skip directory if there is no commit date (usually that
+              # means that we don't have read access to it)
+              next if entry['kind'] == 'dir' && commit_date.nil?
+              name = entry['name']['__content__']
+              entries << Entry.new({:name => URI.unescape(name),
+                          :path => ((path.empty? ? "" : "#{path}/") + name),
+                          :kind => entry['kind'],
+                          :size => ((s = entry['size']) ? s['__content__'].to_i : nil),
+                          :lastrev => Revision.new({
+                            :identifier => commit['revision'],
+                            :time => Time.parse(commit_date['__content__'].to_s).localtime,
+                            :author => ((a = commit['author']) ? a['__content__'] : nil)
                             })
-              end
-            rescue Exception => e
-              logger.error("Error parsing svn output: #{e.message}")
-              logger.error("Output was:\n #{output}")
+                          })
             end
+            logger.debug("Found #{entries.size} entries in the repository for #{target(path)}") if logger && logger.debug?
+            entries.sort_by_name
           end
-          return nil if $? && $?.exitstatus != 0
-          logger.debug("Found #{entries.size} entries in the repository for #{target(path)}") if logger && logger.debug?
-          entries.sort_by_name
         end
 
         def properties(path, identifier=nil)
           # proplist xml output supported in svn 1.5.0 and higher
           return nil unless self.class.client_version_above?([1, 5, 0])
 
-          identifier = (identifier and identifier.to_i > 0) ? identifier.to_i : "HEAD"
-          cmd = "#{self.class.sq_bin} proplist --verbose --xml #{target(path)}@#{identifier}"
-          cmd << credentials_string
+          identifier = initialize_identifier(identifier)
+          cmd_args = ['proplist', '--verbose', '--xml', "#{target(path)}@#{identifier}", credentials_string]
           properties = {}
-          shellout(cmd) do |io|
+          scm_cmd(cmd_args) do |io|
             output = io.read
             if output.respond_to?(:force_encoding)
               output.force_encoding('UTF-8')
             end
-            begin
-              doc = ActiveSupport::XmlMini.parse(output)
-              each_xml_element(doc['properties']['target'], 'property') do |property|
-                properties[ property['name'] ] = property['__content__'].to_s
-              end
-            rescue
+            doc = ActiveSupport::XmlMini.parse(output)
+            each_xml_element(doc['properties']['target'], 'property') do |property|
+              properties[ property['name'] ] = property['__content__'].to_s
             end
+            properties
           end
-          return nil if $? && $?.exitstatus != 0
-          properties
         end
 
         def revisions(path=nil, identifier_from=nil, identifier_to=nil, options={})
           path ||= ''
-          identifier_from = (identifier_from && identifier_from.to_i > 0) ? identifier_from.to_i : "HEAD"
-          identifier_to = (identifier_to && identifier_to.to_i > 0) ? identifier_to.to_i : 1
+          identifier_from = initialize_identifier(identifier_from)
+          identifier_to   = initialize_identifier(identifier_to, 1)
+
+          cmd_args = ['log', '--xml', '-r', "#{identifier_from}:#{identifier_to}", credentials_string]
+          cmd_args << " --verbose " if  options[:with_paths]
+          cmd_args << " --limit #{options[:limit].to_i}" if options[:limit]
+          cmd_args << target(path)
+
           revisions = Revisions.new
-          cmd = "#{self.class.sq_bin} log --xml -r #{identifier_from}:#{identifier_to}"
-          cmd << credentials_string
-          cmd << " --verbose " if  options[:with_paths]
-          cmd << " --limit #{options[:limit].to_i}" if options[:limit]
-          cmd << ' ' + target(path)
-          shellout(cmd) do |io|
+
+          scm_cmd(cmd_args) do |io|
             output = io.read
             if output.respond_to?(:force_encoding)
               output.force_encoding('UTF-8')
             end
-            begin
-              doc = ActiveSupport::XmlMini.parse(output)
-              each_xml_element(doc['log'], 'logentry') do |logentry|
-                paths = []
+            doc = ActiveSupport::XmlMini.parse(output)
+            each_xml_element(doc['log'], 'logentry') do |logentry|
+              paths = []
+
+              if logentry['paths'] && logentry['paths']['path']
                 each_xml_element(logentry['paths'], 'path') do |path|
                   paths << {:action => path['action'],
                             :path => path['__content__'],
                             :from_path => path['copyfrom-path'],
                             :from_revision => path['copyfrom-rev']
                             }
-                end if logentry['paths'] && logentry['paths']['path']
-                paths.sort! { |x,y| x[:path] <=> y[:path] }
-
-                revisions << Revision.new({:identifier => logentry['revision'],
-                              :author => (logentry['author'] ? logentry['author']['__content__'] : ""),
-                              :time => Time.parse(logentry['date']['__content__'].to_s).localtime,
-                              :message => logentry['msg']['__content__'],
-                              :paths => paths
-                            })
+                end
               end
-            rescue
+              paths.sort! { |x,y| x[:path] <=> y[:path] }
+
+              revisions << Revision.new({:identifier => logentry['revision'],
+                            :author => (logentry['author'] ? logentry['author']['__content__'] : ""),
+                            :time => Time.parse(logentry['date']['__content__'].to_s).localtime,
+                            :message => logentry['msg']['__content__'],
+                            :paths => paths
+                          })
             end
+            revisions
           end
-          return nil if $? && $?.exitstatus != 0
-          revisions
         end
 
         def diff(path, identifier_from, identifier_to=nil, type="inline")
           path ||= ''
-          identifier_from = (identifier_from and identifier_from.to_i > 0) ? identifier_from.to_i : ''
 
-          identifier_to = (identifier_to and identifier_to.to_i > 0) ? identifier_to.to_i : (identifier_from.to_i - 1)
+          identifier_from = initialize_identifier(identifier_from, '')
+          identifier_to = initialize_identifier(identifier_to, identifier_from.to_i - 1)
 
-          cmd = "#{self.class.sq_bin} diff -r "
-          cmd << "#{identifier_to}:"
-          cmd << "#{identifier_from}"
-          cmd << " #{target(path)}@#{identifier_from}"
-          cmd << credentials_string
+          cmd_args = ["diff -r",
+                      "#{identifier_to}:#{identifier_from}",
+                      "#{target(path)}@#{identifier_from}",
+                      credentials_string]
           diff = []
-          shellout(cmd) do |io|
+          scm_cmd(cmd_args) do |io|
             io.each_line do |line|
               diff << line
             end
+            diff
           end
-          return nil if $? && $?.exitstatus != 0
-          diff
         end
 
         def cat(path, identifier=nil)
-          identifier = (identifier and identifier.to_i > 0) ? identifier.to_i : "HEAD"
-          cmd = "#{self.class.sq_bin} cat #{target(path)}@#{identifier}"
-          cmd << credentials_string
-          cat = nil
-          shellout(cmd) do |io|
+          identifier = initialize_identifier(identifier)
+
+          cmd_args = ['cat', "#{target(path)}@#{identifier}", credentials_string]
+          scm_cmd(cmd_args) do |io|
             io.binmode
-            cat = io.read
+            io.read
           end
-          return nil if $? && $?.exitstatus != 0
-          cat
+        end
+
+        def save_entry_in_file(f, path, identifier)
+          identifier = initialize_identifier(identifier)
+          cmd_args = ['cat', "#{target(path)}@#{identifier}", credentials_string]
+          scm_cmd(cmd_args, f.path)
         end
 
         def annotate(path, identifier=nil)
-          identifier = (identifier and identifier.to_i > 0) ? identifier.to_i : "HEAD"
-          cmd = "#{self.class.sq_bin} blame #{target(path)}@#{identifier}"
-          cmd << credentials_string
+          identifier = initialize_identifier(identifier)
+          cmd_args = ['blame', "#{target(path)}@#{identifier}", credentials_string]
           blame = Annotate.new
-          shellout(cmd) do |io|
+          scm_cmd(cmd_args) do |io|
             io.each_line do |line|
               next unless line =~ %r{^\s*(\d+)\s*(\S+)\s(.*)$}
               blame.add_line($3.rstrip, Revision.new(:identifier => $1.to_i, :author => $2.strip))
             end
+            blame
           end
-          return nil if $? && $?.exitstatus != 0
-          blame
         end
 
         private
+
+        def initialize_identifier(identifier, default="HEAD")
+          (identifier && identifier.to_i > 0) ? identifier.to_i : default
+        end
 
         def credentials_string
           str = ''

--- a/test/functional/repositories_bazaar_controller_test.rb
+++ b/test/functional/repositories_bazaar_controller_test.rb
@@ -96,7 +96,9 @@ class RepositoriesBazaarControllerTest < ActionController::TestCase
       get :entry, :id => 3, :path => ['directory', 'doc-ls.txt'], :format => 'raw'
       assert_response :success
       # File content
-      assert @response.body.include?('Show help message')
+      output = StringIO.new
+      @response.body.call(@response, output)
+      assert_match('Show help message', output.string)
     end
 
     def test_directory_entry

--- a/test/functional/repositories_filesystem_controller_test.rb
+++ b/test/functional/repositories_filesystem_controller_test.rb
@@ -55,6 +55,7 @@ class RepositoriesFilesystemControllerTest < ActionController::TestCase
       get :entry, :id => PRJ_ID, :path => ['test']
       assert_response :success
       assert_template 'entry'
+
       assert_tag :tag => 'th',
                  :content => '1',
                  :attributes => { :class => 'line-num' },

--- a/test/functional/repositories_git_controller_test.rb
+++ b/test/functional/repositories_git_controller_test.rb
@@ -13,6 +13,7 @@
 #++
 require File.expand_path('../../test_helper', __FILE__)
 require 'repositories_controller'
+require 'stringio'
 
 # Re-raise errors caught by the controller.
 class RepositoriesController; def rescue_action(e) raise e end; end
@@ -142,7 +143,9 @@ class RepositoriesGitControllerTest < ActionController::TestCase
       get :entry, :id => 3, :path => ['sources', 'watchers_controller.rb'], :format => 'raw'
       assert_response :success
       # File content
-      assert @response.body.include?('WITHOUT ANY WARRANTY')
+      output = StringIO.new
+      assert_nothing_raised{ @response.body.call(@response, output) }
+      assert output.string.include?('WITHOUT ANY WARRANTY')
     end
 
     def test_directory_entry

--- a/test/functional/repositories_mercurial_controller_test.rb
+++ b/test/functional/repositories_mercurial_controller_test.rb
@@ -212,7 +212,9 @@ class RepositoriesMercurialControllerTest < ActionController::TestCase
       get :entry, :id => PRJ_ID, :path => ['sources', 'watchers_controller.rb'], :format => 'raw'
       assert_response :success
       # File content
-      assert @response.body.include?('WITHOUT ANY WARRANTY')
+      output = StringIO.new
+      assert_nothing_raised{ @response.body.call(@response, output) }
+      assert output.string.include?('WITHOUT ANY WARRANTY')
     end
 
     def test_entry_binary_force_download

--- a/test/unit/lib/redmine/scm/adapters/mercurial_adapter_test.rb
+++ b/test/unit/lib/redmine/scm/adapters/mercurial_adapter_test.rb
@@ -150,7 +150,7 @@ begin
       end
 
       def test_annotate
-        assert_equal [], @adapter.annotate("sources/welcome_controller.rb").lines
+        assert_nil @adapter.annotate("sources/welcome_controller.rb")
         [2, '400bb8672109', '400', 400].each do |r|
           ann = @adapter.annotate('sources/welcome_controller.rb', r)
           assert ann


### PR DESCRIPTION
Hi there,

I've refactored the code inside lib/scm. This refactoring does 3 main things:
- When downloading a file via the repository view, a temporary file is used. This decreases the download time **dramatically** on big files - A 20MB file took 4 minutes to start downloading on my system, and now it starts almost immediately.
- Adapters behave more cohesively now. For example, the error recovery is abstracted to the abstract adapter (on the current implementation, SVN returns nil on error, while mercurial throws an exception). In general, now it's easier to change one setting and modify how all adapters work.
- Passwords are removed from all log messages

Since most of the stuff I did was moving code around, there was little to change in the way of tests. All of them pass. I've modified very little public methods, so this should be very backwards-compatible.

Disclaimer: I've been using the subversion and git repositories in a production server for some time now with no issues and very happy users downloading 40MB files from their repos. I'm pretty confident that the other SCMs will also work (the tests pass) but I have not personally used them in production.
