### PR TITLE
Fix a typo when calculating the menu X position. #1007

### DIFF
--- a/public/javascripts/context_menu.jquery.js
+++ b/public/javascripts/context_menu.jquery.js
@@ -154,7 +154,7 @@
                         }
 
                         if(maxHeight > $(window).height()) {
-                            renderY =+ menu.height();
+                            renderY -= menu.height();
                             menu.addClass(reverseYClass);
                         } else {
                             menu.removeClass(reverseYClass);


### PR DESCRIPTION
Turns out there was a typo when calculating the X position when the menu could go off the bottom of the screen. This corrects that to the same as the original JS file.
