### PR TITLE
#944: Fix Engines::Testing.set_fixture_path with temporary_fixtures_directory

### DIFF
--- a/vendor/plugins/engines/lib/engines/testing.rb
+++ b/vendor/plugins/engines/lib/engines/testing.rb
@@ -54,7 +54,7 @@ require 'fileutils'
 #
 module Engines::Testing
   mattr_accessor :temporary_fixtures_directory
-  self.temporary_fixtures_directory = FileUtils.mkdir_p(File.join(Dir.tmpdir, "rails_fixtures"))
+  self.temporary_fixtures_directory = [*FileUtils.mkdir_p(File.join(Dir.tmpdir, "rails_fixtures"))].first
   
   # Copies fixtures from plugins and the application into a temporary directory 
   # (Engines::Testing.temporary_fixtures_directory). 

--- a/vendor/plugins/engines/test/unit/testing_test.rb
+++ b/vendor/plugins/engines/test/unit/testing_test.rb
@@ -7,14 +7,31 @@ class TestingTest < Test::Unit::TestCase
     @filename = File.join(Engines::Testing.temporary_fixtures_directory, 'testing_fixtures.yml')
     File.delete(@filename) if File.exists?(@filename)
   end
-  
+
   def teardown
     File.delete(@filename) if File.exists?(@filename)
+    if File.directory?(Engines::Testing.temporary_fixtures_directory)
+      FileUtils.rm_r(Engines::Testing.temporary_fixtures_directory)
+    end
   end
 
   def test_should_copy_fixtures_files_to_tmp_directory
     assert !File.exists?(@filename)
     Engines::Testing.setup_plugin_fixtures
     assert File.exists?(@filename)
+  end
+
+  def test_creates_temporary_fixtures_directory
+    assert File.directory?(Engines::Testing.temporary_fixtures_directory)
+  end
+
+  def test_set_fixture_path_doesnt_break_load_path
+    assert_nothing_raised "require has failed after call to Engines::Testing.set_fixture_path" do
+      require 'tmpdir' # XXX this can be anything, even loaded file
+    end
+  end
+
+  def test_fixtures_are_in_load_path
+    assert $LOAD_PATH.include?(Engines::Testing.temporary_fixtures_directory)
   end
 end


### PR DESCRIPTION
See https://www.chiliproject.org/issues/944

Following the changes in [#952](https://www.chiliproject.org/issues/952) and #176

This is rather a minimal hack to make things compatible both in Ruby 1.8 and 1.9, without further refactoring of Engines::Testing class.
