### PR TITLE
992 git 404 v2

### DIFF
--- a/lib/redmine/scm/adapters/git_adapter.rb
+++ b/lib/redmine/scm/adapters/git_adapter.rb
@@ -83,8 +83,9 @@ module Redmine
             end
           end
           @branches.sort!
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def tags
@@ -93,8 +94,9 @@ module Redmine
           scm_cmd(*cmd_args) do |io|
             @tags = io.readlines.sort!.map{|t| t.strip}
           end
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def default_branch
@@ -134,8 +136,9 @@ module Redmine
             end
           end
           entries.sort_by_name
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def lastrev(path, rev)
@@ -162,8 +165,9 @@ module Redmine
               logger.error("The revision '#{path}' has a wrong format")
               return nil
           end
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def revisions(path, identifier_from, identifier_to, options={})
@@ -257,8 +261,9 @@ module Redmine
             end
           end
           revisions
-        rescue ScmCommandAborted
-          revisions
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def diff(path, identifier_from, identifier_to=nil)
@@ -277,8 +282,9 @@ module Redmine
             end
           end
           diff
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def annotate(path, identifier=nil)
@@ -312,8 +318,9 @@ module Redmine
             end
           end
           blame
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         def cat(path, identifier=nil)
@@ -328,8 +335,9 @@ module Redmine
             cat = io.read
           end
           cat
-        rescue ScmCommandAborted
-          nil
+        rescue ScmCommandAborted => exception
+          logger.error exception
+          raise
         end
 
         class Revision < Redmine::Scm::Adapters::Revision


### PR DESCRIPTION
Simplified commit, which allows better error messages than a 404 when there is a scm error.
