### PR TITLE
[#1024] Select multiple issues with shift

### DIFF
--- a/public/javascripts/context_menu.jquery.js
+++ b/public/javascripts/context_menu.jquery.js
@@ -174,6 +174,7 @@
             addSelection: function(element) {
                element.addClass(contextMenuSelectionClass);
                methods.checkSelectionBox(element, true);
+               methods.clearDocumentSelection();
             },
             isSelected: function(element) {
                 return element.hasClass(contextMenuSelectionClass);
@@ -208,6 +209,13 @@
                         methods.addSelection(self);
                     }
                 });
+            },
+            clearDocumentSelection: function() {
+                if(document.selection) {
+                    document.selection.clear();
+                } else {
+                    window.getSelection().removeAllRanges();
+                }
             }
         };
 


### PR DESCRIPTION
Few rookie mistakes with the original and should've been caught.

The row selection was missing the '.' to make it look for elements with the class.

Secondly, you can't compare jQuery elements with each other, so you need to get the DOMElement when you want to check if they are the same node.

I've re-written it to be a bit more jQuery-y as well and added in a missing function from the port that clears any selected text. Without that second commit then shift-selecting results is a huge block of selected text.

Finally, I've added a minor bug fix from the original Redmine JS as well. If you shift-selected the same issue you had just clicked on then any issue below the issue would be selected (the toggling wouldn't un-toggle).
