### PR TITLE
Fix option parsing for gravatars #1034

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -959,7 +959,9 @@ module ApplicationHelper
   def gravatar(email, options={})
     gravatarify_options = {}
     gravatarify_options[:secure] = options.delete :ssl
-    [:default, :size, :rating, :filetype].each {|key| gravatarify_options[:key] = options.delete :key}
+    [:default, :size, :rating, :filetype].each {|key| gravatarify_options[key] = options.delete key}
+    # Default size is 50x50 px
+    gravatarify_options[:size] ||= 50
     gravatarify_options[:html] = options
     gravatar_tag email, gravatarify_options
   end

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -664,6 +664,11 @@ RAW
     Setting.gravatar_enabled = '1'
     assert avatar(User.find_by_mail('jsmith@somenet.foo')).include?(Digest::MD5.hexdigest('jsmith@somenet.foo'))
     assert avatar('jsmith <jsmith@somenet.foo>').include?(Digest::MD5.hexdigest('jsmith@somenet.foo'))
+    # Default size is 50
+    assert avatar('jsmith <jsmith@somenet.foo>').include?('s=50')
+    assert avatar('jsmith <jsmith@somenet.foo>', :size => 24).include?('s=24')
+    # Non-avatar options should be considered html options
+    assert avatar('jsmith <jsmith@somenet.foo>', :title => 'John Smith').include?('title="John Smith"')
     assert_nil avatar('jsmith')
     assert_nil avatar(nil)
 


### PR DESCRIPTION
In addition to that:
- the default size was 50px in the old lib, this has been restored
- some tests to test the default and option parsing
