### PR TITLE
Replace gradient background images with CSS3

### DIFF
--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -2617,7 +2617,13 @@ a:hover {
 
 #account-nav {
   display: block;
-  background: url(../images/background_top_navigation.png) repeat-x left top;
+  background: #a0070b url(../images/background_top_navigation.png) repeat-x left top; /* Old browsers */
+  background: -moz-linear-gradient(top, #a0070b 0%, #6b0406 67%, #6a0406 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#a0070b), color-stop(67%,#6b0406), color-stop(100%,#6a0406)); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(top, #a0070b 0%,#6b0406 67%,#6a0406 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(top, #a0070b 0%,#6b0406 67%,#6a0406 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(top, #a0070b 0%,#6b0406 67%,#6a0406 100%); /* IE10+ */
+  background: linear-gradient(to bottom, #a0070b 0%,#6b0406 67%,#6a0406 100%); /* W3C */
 }
 
 #logo {
@@ -2640,7 +2646,13 @@ a:hover {
 }
 
 #header {
-  background: url(../images/background_header.png) repeat-x 20px;
+  background: rgb(40,40,40) url(../images/background_header.png) repeat-x 20px; /* Old browsers */
+  background: -moz-linear-gradient(top, rgba(40,40,40,1) 0%, rgba(33,33,33,1) 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(40,40,40,1)), color-stop(100%,rgba(33,33,33,1))); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(top, rgba(40,40,40,1) 0%,rgba(33,33,33,1) 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(top, rgba(40,40,40,1) 0%,rgba(33,33,33,1) 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(top, rgba(40,40,40,1) 0%,rgba(33,33,33,1) 100%); /* IE10+ */
+  background: linear-gradient(to bottom, rgba(40,40,40,1) 0%,rgba(33,33,33,1) 100%); /* W3C */
   height: 43px;
   font: arial,19px,white;
 }
@@ -2847,7 +2859,13 @@ input: -moz-placeholder {
 #breadcrumb {
   height: 38px;
   line-height: 38px;
-  background: url(../images/background_breadcrumb.png) repeat-x left top;
+  background: rgb(255,255,255) url(../images/background_breadcrumb.png) repeat-x left top; /* Old browsers */
+  background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 11%, rgba(228,228,228,1) 97%, rgba(217,217,217,1) 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,1)), color-stop(11%,rgba(255,255,255,1)), color-stop(97%,rgba(228,228,228,1)), color-stop(100%,rgba(217,217,217,1))); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* IE10+ */
+  background: linear-gradient(to bottom, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* W3C */
   border-bottom: 1px #d9d9d9;
   color: #777777;
   padding-left: 15px;
@@ -3222,7 +3240,13 @@ form#issue-list {
 
 #content table th {
   font-weight: normal;
-  background: #f3f3f3 url(../images/gradient-down.png) repeat-x;
+  background: #f3f3f3 url(../images/gradient-down.png) repeat-x; /* Old browsers */
+  background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 11%, rgba(228,228,228,1) 97%, rgba(217,217,217,1) 100%); /* FF3.6+ */
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,1)), color-stop(11%,rgba(255,255,255,1)), color-stop(97%,rgba(228,228,228,1)), color-stop(100%,rgba(217,217,217,1))); /* Chrome,Safari4+ */
+  background: -webkit-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* Chrome10+,Safari5.1+ */
+  background: -o-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* Opera 11.10+ */
+  background: -ms-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* IE10+ */
+  background: linear-gradient(to bottom, rgba(255,255,255,1) 0%,rgba(255,255,255,1) 11%,rgba(228,228,228,1) 97%,rgba(217,217,217,1) 100%); /* W3C */
 }
 
 #content table.issues td,


### PR DESCRIPTION
Some of the backgrounds in the ChiliProject theme are simple gradients. These can be replaced with much lighter (for the clients) versions using CSS3.

Offers the benefits of smaller total download sizes but also fewer HTTP requests and the round trip time they take, with a small file size increase for the CSS file (with gzip I would imaging to be very minimal).
