### PR TITLE
[#1084] Remove the inline JS with simpler jQuery and CSS

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -800,7 +800,7 @@ module ApplicationHelper
         toc_class << ' left' if $1 == '_left'
 
         out = "<fieldset class=\"header_collapsible collapsible #{toc_class}\">"
-        out << "<legend onclick=\"toggleFieldset(this);\"><span>#{l(:label_toc)}</span></legend>"
+        out << "<legend><span>#{l(:label_toc)}</span></legend>"
         out << "<div>"
         out << "<ul class=\"toc\"><li>"
         root = headings.map(&:first).min

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -3,8 +3,8 @@
 <% form_tag(calendar_path, :method => :put, :id => 'query_form') do %>
   <%= hidden_field_tag('project_id', @project.to_param) if @project%>
 <fieldset id="filters" class="collapsible <%= @query.new_record? ? "" : "collapsed" %>">
-  <legend onclick="toggleFieldset(this);"><%= l(:label_filter_plural) %></legend>
-  <div style="<%= @query.new_record? ? "" : "display: none;" %>">
+  <legend><%= l(:label_filter_plural) %></legend>
+  <div>
     <%= render :partial => 'queries/filters', :locals => {:query => @query} %>
   </div>
 </fieldset>

--- a/app/views/gantts/show.html.erb
+++ b/app/views/gantts/show.html.erb
@@ -4,7 +4,7 @@
 <% form_tag(gantt_path(:month => params[:month], :year => params[:year], :months => params[:months]), :method => :put, :id => 'query_form') do %>
   <%= hidden_field_tag('project_id', @project.to_param) if @project%>
 <fieldset id="filters" class="collapsible <%= @query.new_record? ? "" : "collapsed" %>">
-  <legend onclick="toggleFieldset(this);"><%= l(:label_filter_plural) %></legend>
+  <legend><%= l(:label_filter_plural) %></legend>
 	<div style="<%= @query.new_record? ? "" : "display: none;" %>">
     <%= render :partial => 'queries/filters', :locals => {:query => @query} %>
   </div>

--- a/app/views/issues/_edit.rhtml
+++ b/app/views/issues/_edit.rhtml
@@ -38,8 +38,9 @@
     <%= call_hook(:view_issues_edit_notes_bottom, { :issue => @issue, :notes => @notes, :form => f }) %>
     </fieldset>
 
-    <fieldset id="attachments" class="header_collapsible collapsible collapsed"><legend onclick="toggleFieldset(this);"><%=l(:label_attachment_plural)%></legend>
-      <div style="display: none;">
+    <fieldset id="attachments" class="header_collapsible collapsible collapsed">
+      <legend><%=l(:label_attachment_plural)%></legend>
+      <div>
       <%= render :partial => 'attachments/form' %>
       </div>
     </fieldset>

--- a/app/views/issues/index.rhtml
+++ b/app/views/issues/index.rhtml
@@ -18,14 +18,14 @@
     <%= hidden_field_tag('project_id', @project.to_param) if @project %>
 		<div id="query_form_content" class="hide-when-print">
     <fieldset id="filters" class="header_collapsible collapsible <%= @query.new_record? ? "" : "collapsed" %>">
-    	<legend onclick="toggleFieldset(this);"><%= l(:label_filter_plural) %></legend>
-    	<div class="filter-fields" style="<%= @query.new_record? ? "" : "display: none;" %>">
+        <legend><%= l(:label_filter_plural) %></legend>
+        <div class="filter-fields">
     		<%= render :partial => 'queries/filters', :locals => {:query => @query} %>
     	</div>
     </fieldset>
     <fieldset id="column_options" class="header_collapsible collapsible collapsed">
-    	<legend onclick="toggleFieldset(this);"><%= l(:label_options) %></legend>
-    	<div style="display: none;">
+        <legend><%= l(:label_options) %></legend>
+        <div>
     		<table>
     			<tr>
     				<td><%= l(:field_column_names) %></td>

--- a/app/views/timelog/_date_range.rhtml
+++ b/app/views/timelog/_date_range.rhtml
@@ -1,5 +1,5 @@
 <fieldset id="date-range" class="collapsible">
-<legend onclick="toggleFieldset(this);"><%= l(:label_date_range) %></legend>
+<legend><%= l(:label_date_range) %></legend>
 <div>
 <p>
 <%= label_tag "period_type_list", l(:description_date_range_list), :class => "hidden-for-sighted" %>

--- a/app/views/workflows/edit.rhtml
+++ b/app/views/workflows/edit.rhtml
@@ -28,20 +28,18 @@
       <%= render :partial => 'form', :locals => {:name => 'always', :workflows => @workflows['always']} %>
 
       <fieldset class="collapsible" style="padding: 0; margin-top: 0.5em;">
-        <legend onclick="toggleFieldset(this);"><%= l(:label_additional_workflow_transitions_for_author) %></legend>
+        <legend><%= l(:label_additional_workflow_transitions_for_author) %></legend>
         <div id="author_workflows" style="margin: 0.5em 0 0.5em 0;">
           <%= render :partial => 'form', :locals => {:name => 'author', :workflows => @workflows['author']} %>
         </div>
       </fieldset>
-      <%= javascript_tag "hideFieldset($('author_workflows'))" unless @workflows['author'].present? %>
 
       <fieldset class="collapsible" style="padding: 0;">
-        <legend onclick="toggleFieldset(this);"><%= l(:label_additional_workflow_transitions_for_assignee) %></legend>
+        <legend><%= l(:label_additional_workflow_transitions_for_assignee) %></legend>
         <div id="assignee_workflows" style="margin: 0.5em 0 0.5em 0;">
       <%= render :partial => 'form', :locals => {:name => 'assignee', :workflows => @workflows['assignee']} %>
         </div>
       </fieldset>
-      <%= javascript_tag "hideFieldset($('assignee_workflows'))" unless @workflows['assignee'].present? %>
     </div>
     <%= submit_tag l(:button_save) %>
   <% end %>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -658,4 +658,8 @@ jQuery(document).ready(function($) {
   }
 
   setUpDialogWindow();
+
+  $('.collapsible').on('click', 'legend', function(e) {
+    $(this).parent().toggleClass('collapsed');
+  });
 });

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -898,73 +898,74 @@ div.issue div.subject h3 {
 }
 
 fieldset#filters legend {
-  -moz-border-radius-bottomleft: 0px;
-  -moz-border-radius-bottomright: 0px;
-  -webkit-border-bottom-left-radius: 0px;
-  -webkit-border-bottom-right-radius: 0px;
-  border-bottom-left-radius: 0px;
-  border-bottom-right-radius: 0px;
+  -moz-border-radius-bottomleft: 0;
+  -moz-border-radius-bottomright: 0;
+  -webkit-border-bottom-left-radius: 0;
+  -webkit-border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 fieldset#column_options legend {
-  -moz-border-radius-topleft: 0px;
-  -moz-border-radius-topright: 0px;
-  -webkit-border-top-left-radius: 0px;
-  -webkit-border-top-right-radius: 0px;
-  border-top-left-radius: 0px;
-  border-top-right-radius: 0px;
+  -moz-border-radius-topleft: 0;
+  -moz-border-radius-topright: 0;
+  -webkit-border-top-left-radius: 0;
+  -webkit-border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 #content fieldset.collapsible.header_collapsible {
-  padding-top: 0px;
-  padding-bottom: 0px;
-  border: 0px;
-  margin: 0px;
+  padding-top: 0;
+  padding-bottom: 0;
+  border: 0;
+  margin: 0;
 }
 
 fieldset.collapsible.header_collapsible > div {
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 0;
 }
 
 fieldset.collapsible.header_collapsible > * {
-  border-left: 1px solid #E6E6E6;
-  border-right: 1px solid #E6E6E6;
-  border-bottom: 1px solid #E6E6E6;
+  border: 1px solid #E6E6E6;
+  border-top: none;
   width: 100%;
 }
 
 fieldset.collapsible.header_collapsible legend {
-  background: #E6E6E6 url(../images/double_arrow_toggle_up.png) no-repeat 99% 50%;
-  cursor: pointer;
+  background: #E6E6E6;
   padding-left: 0px;
   width: 100%;
   height: 23px;
   line-height: 23px;
   text-indent: 8px;
-  -moz-border-radius-topleft: 5px;
-  -moz-border-radius-topright: 5px;
   -webkit-border-top-left-radius: 5px;
   -webkit-border-top-right-radius: 5px;
+  -moz-border-radius-topleft: 5px;
+  -moz-border-radius-topright: 5px;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
-  -moz-border-radius-bottomleft: 0px;
-  -moz-border-radius-bottomright: 0px;
-  -webkit-border-bottom-left-radius: 0px;
-  -webkit-border-bottom-right-radius: 0px;
-  border-bottom-left-radius: 0px;
-  border-bottom-right-radius: 0px;
 }
 
-fieldset.collapsible.header_collapsible legend:hover {
+.js fieldset.collapsible.header_collapsible legend {
+  background-image: url(../images/double_arrow_toggle_up.png);
+  background-position: 99% 50%;
+  background-repeat: no-repeat;
+}
+
+.js fieldset.collapsible.header_collapsible legend:hover {
   background-color: #d8d8d8;
 }
 
-fieldset.collapsible.collapsed.header_collapsible legend {
-  background-image: url(../images/double_arrow_toggle_down.png);
+.js fieldset.collapsible legend:hover {
+  cursor: pointer;
+}
+
+.js fieldset.collapsible.collapsed.header_collapsible legend {
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
+  background-image: url(../images/double_arrow_toggle_down.png);
 }
 
 fieldset.collapsible {
@@ -982,12 +983,24 @@ fieldset.collapsible.collapsed.borders {
 
 fieldset.collapsible legend {
   padding-left: 16px;
-  background: url(../images/arrow_expanded.png) no-repeat 0% 40%;
-  cursor: pointer;
 }
 
-fieldset.collapsible.collapsed legend {
+.js fieldset.collapsible legend {
+  background-image: url(../images/arrow_expanded.png);
+  background-repeat: no-repeat;
+  background-position: 0% 40%;
+}
+
+.js fieldset.collapsible.collapsed legend {
   background-image: url(../images/arrow_collapsed.png);
+}
+
+.js fieldset.collapsible div {
+  display: block;
+}
+
+.js fieldset.collapsible.collapsed div {
+  display: none;
 }
 
 fieldset#date-range p {


### PR DESCRIPTION
Removes the inline JS from the fieldsets and giggles the CSS around a bit so that it plays nicely if the user doesn't have JS enabled.

Want to have another look over the CSS since I think it can be made a bit tidier.
