### PR TITLE
Use Darcs 2.4.4 on Travis #1142

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,12 @@ matrix:
     - rvm: rbx-18mode
 before_install:
   - "sudo apt-get update -qq"
-  - "sudo apt-get --no-install-recommends install bzr cvs darcs git mercurial subversion"
+  - "sudo apt-get --no-install-recommends install bzr cvs git mercurial subversion"
+
+  # Our tests don't work on Darcs >= 2.5, so we use Darcs 2.3 from Ubuntu Lucy
+  - "sudo apt-get --no-install-recommends install libc6 libcurl3-gnutls libgmp3c2 libncurses5 zlib1g"
+  - "wget http://de.archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi5_3.0.9-1_i386.deb -O /tmp/libffi5_3.0.9-1_i386.deb; sudo dpkg -i /tmp/libffi5_3.0.9-1_i386.deb"
+  - "wget http://de.archive.ubuntu.com/ubuntu/pool/universe/d/darcs/darcs_2.3.0-3_i386.deb -O /tmp/darcs_2.3.0-3_i386.deb; sudo dpkg -i /tmp/darcs_2.3.0-3_i386.deb"
 before_script:
   - "rake ci:travis:prepare"
 branches:


### PR DESCRIPTION
We are not yet compatible to Darcs >= 2.5, so we use 2.4.4 until we are compatible with newer versions.

This should fix the current test failures on Travis and is thus a workaround for https://www.chiliproject.org/issues/1142
