### PR TITLE
Correctly save the subprojects setting when editing queries #1188

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -43,6 +43,7 @@ class QueriesController < ApplicationController
       @query.add_filters(params[:fields] || params[:f], params[:operators] || params[:op], params[:values] || params[:v]) if params[:fields] || params[:f]
       @query.attributes = params[:query]
       @query.project = nil if params[:query_is_for_all]
+      @query.display_subprojects = params[:display_subprojects] if params[:display_subprojects].present?
       @query.is_public = false unless User.current.allowed_to?(:manage_public_queries, @project) || User.current.admin?
       @query.group_by ||= params[:group_by]
       @query.column_names = params[:c] if params[:c]

--- a/test/functional/queries_controller_test.rb
+++ b/test/functional/queries_controller_test.rb
@@ -187,6 +187,25 @@ class QueriesControllerTest < ActionController::TestCase
     assert q.valid?
   end
 
+  def test_edit_query_with_subprojects
+    q = Query.find(3)
+    q.display_subprojects = false
+    q.save
+
+    @request.session[:user_id] = 1
+    post :edit,
+         :id => 3,
+         :confirm => '1',
+         :default_columns => '1',
+         :fields => ['tracker_id'],
+         :operators => {'tracker_id' => '='},
+         :values => {'tracker_id' => ['3']},
+         :display_subprojects => '1'
+
+    q.reload
+    assert q.display_subprojects?
+  end
+
   def test_get_edit_project_private_query
     @request.session[:user_id] = 3
     get :edit, :id => 2


### PR DESCRIPTION
When editing an issue query, the "display subprojects" parameter isn't stored properly.

https://www.chiliproject.org/issues/1188
