### PR TITLE
[WIP] Welcome Page Configuration

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -17,7 +17,19 @@ class WelcomeController < ApplicationController
 
   def index
     @news = News.latest User.current
-    @projects = Project.latest User.current
+    @latest_projects = Project.latest User.current
+
+    visible_projects = Project.visible().find(:all, :order => "projects.name")
+    @admin_projects = []
+    @my_projects = []
+
+    visible_projects.each do |project|
+      if User.current.member_of?(project)
+        @my_projects << project
+      else
+        @admin_projects << project
+      end
+    end
   end
 
   def robots

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -16,6 +16,7 @@ module SettingsHelper
   def administration_settings_tabs
     tabs = [{:name => 'general', :partial => 'settings/general', :label => :label_general},
             {:name => 'display', :partial => 'settings/display', :label => :label_display},
+            {:name => 'welcome_page', :partial => 'settings/welcome_page', :label => :label_welcome_page},
             {:name => 'authentication', :partial => 'settings/authentication', :label => :label_authentication},
             {:name => 'projects', :partial => 'settings/projects', :label => :label_project_plural},
             {:name => 'issues', :partial => 'settings/issues', :label => :label_issue_tracking},

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -29,5 +29,4 @@ module WelcomeHelper
     html += " |" unless html.empty?
     return html
   end
-  
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -13,4 +13,21 @@
 #++
 
 module WelcomeHelper
+  
+  def project_sublinks(project, modules=[])
+    html = ""
+    html += " | #{link_to l(:label_issue_plural), :controller => 'issues', :action => 'index', :project_id => project } " if modules.include?("issue_tracking")
+    html += " | #{link_to l(:label_time_tracking), :controller => 'timelog', :action => 'index', :project_id => project } " if modules.include?("time_tracking")
+    html += " | #{link_to l(:label_news), :controller => 'news', :action => 'index', :project_id => project } " if modules.include?("news")
+    html += " | #{link_to l(:label_document_plural), :controller => 'documents', :action => 'index', :id => project } " if modules.include?("documents")
+    html += " | #{link_to l(:label_file_plural), :controller => 'files', :action => 'index', :project_id => project } " if modules.include?("files")
+    html += " | #{link_to l(:label_wiki), :controller => 'wiki', :action => 'show', :project_id => project } " if modules.include?("wiki")
+    html += " | #{link_to l(:label_repository), :controller => 'repositories', :action => 'show', :id => project } " if modules.include?("repository")
+    html += " | #{link_to l(:label_board), :controller => 'boards', :action => 'index', :project_id => project } " if modules.include?("boards")
+    html += " | #{link_to l(:label_calendar), :controller => 'calendars', :action => 'show', :project_id => project } " if modules.include?("calendar")
+    html += " | #{link_to l(:label_gantt), :controller => 'gantts', :action => 'show', :project_id => project } " if modules.include?("gantt")
+    html += " |" unless html.empty?
+    return html
+  end
+  
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -13,7 +13,6 @@
 #++
 
 module WelcomeHelper
-  
   def project_sublinks(project, modules=[])
     html = ""
     html += " | #{link_to l(:label_issue_plural), :controller => 'issues', :action => 'index', :project_id => project } " if modules.include?("issue_tracking")

--- a/app/views/settings/_welcome_page.rhtml
+++ b/app/views/settings/_welcome_page.rhtml
@@ -1,0 +1,15 @@
+<% form_tag({:action => 'edit', :tab => 'welcome_page'}) do %>
+
+<div class="box tabular settings">
+  <p><%= setting_check_box :show_visible_projects %></p>
+  <p><%= setting_multiselect(:visible_projects_links,
+          Redmine::AccessControl.available_project_modules.collect {|m| [l_or_humanize(m, :prefix => "project_module_"), m.to_s]}) %></p>
+</div>
+
+<div class="box tabular settings">
+  <p><%= setting_check_box :show_admin_projects %></p>
+  <p><%= setting_check_box :show_latest_projects %></p>
+</div>
+
+<%= submit_tag l(:button_save) %>
+<% end %>

--- a/app/views/welcome/index.rhtml
+++ b/app/views/welcome/index.rhtml
@@ -13,11 +13,42 @@
 </div>
 
 <div class="splitcontentright">
-    <% if @projects.any? %>
+
+    <% if Setting.show_visible_projects? && @my_projects.any? %>
+    <div class="box projects" id="my_projects">
+      <h3 class=""><%=l(:label_my_projects)%></h3>
+      <% if @my_projects.any? %>
+        <ul>
+          <% @my_projects.each do |project| %>
+            <li><%= link_to_project project %> (<span id="<%= User.current %>-roles"><%= User.current.roles_for_project(project).sort.collect(&:to_s).join(', ') %></span>)</li>
+            <span style="font-size:85%;"><%=project_sublinks(project, project.enabled_module_names & Setting.visible_projects_links) unless Setting.visible_projects_links.count == 0 %></span>
+            <%= textilizable project.short_description, :project => project %>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="nodata"><%=l(:label_no_data) %></p>
+      <% end %>
+    </div>
+  <% end %>
+  
+  <% if User.current.admin? && Setting.show_admin_projects? && @admin_projects.any? %>
+  <div class="box projects" id="admin_projects">
+      <h3><%=l(:label_admin_projects)%></h3>
+      <ul>
+        <% @admin_projects.each do |project| %>
+          <li><%= link_to_project project %> (<span id="<%= User.current %>-roles"><%= User.current.roles_for_project(project).sort.collect(&:to_s).join(', ') %></span>)</li>
+          <span style="font-size:85%;"><%=project_sublinks(project, project.enabled_module_names & Setting.visible_projects_links) unless Setting.visible_projects_links.count == 0 %></span>
+          <%= textilizable project.short_description, :project => project %>
+        <% end %>
+      </ul>
+  </div>
+  <% end %>
+  
+  <% if Setting.show_latest_projects? && @latest_projects.any? %>
 	<div class="projects box">
 	<h3><%=l(:label_project_latest)%></h3>
 		<ul>
-		<% for project in @projects %>
+		<% for project in @latest_projects %>
 		  <% @project = project %>
 			<li>
 			<%= link_to_project project %> (<%= format_time(project.created_on) %>)
@@ -28,7 +59,7 @@
 		</ul>
 	</div>
 	<% end %>
-    <%= call_hook(:view_welcome_index_right, :projects => @projects) %>
+  <%= call_hook(:view_welcome_index_right, :projects => @visible_projects) %>
 </div>
 
 <% content_for :header_tags do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,6 +374,10 @@ en:
   setting_issue_startdate_is_adddate: Use current date as start date for new issues
   setting_mail_handler_confirmation_on_success: "Send confirmation email on successful incoming email"
   setting_mail_handler_confirmation_on_failure: "Send confirmation email on failed incoming email"
+  setting_show_visible_projects: Show visible projects
+  setting_show_admin_projects: Show admin projects
+  setting_visible_projects_links: Visible projects links
+  setting_show_latest_projects: Show lastest projects
 
   permission_add_project: Create project
   permission_add_subprojects: Create subprojects
@@ -783,6 +787,7 @@ en:
   label_document_watchers: Watchers
   label_example: Example
   label_display: Display
+  label_welcome_page: Welcome Page
   label_sort: Sort
   label_ascending: Ascending
   label_descending: Descending
@@ -832,6 +837,8 @@ en:
   label_time_entries: Time entries
   label_new_time_entry: New time entry
   label_time_entry_report: Time entry report
+  label_visible_projects: Visible projects
+  label_admin_projects: Admin projects
 
   button_login: Login
   button_submit: Submit

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -184,3 +184,14 @@ mail_handler_confirmation_on_failure:
   default: 1
 issue_startdate_is_adddate:
   default: 1
+show_visible_projects:
+  default: 1
+show_admin_projects:
+  default: 1
+show_latest_projects:
+  default: 0
+visible_projects_links:
+  serialized: true
+  default:
+  - issue_tracking
+  - wiki


### PR DESCRIPTION
Given the lack of excitement around Pull #243 for the short-lived and possible future implications it may have, I wanted to propose building some more functionality right into the welcome page itself, rather than trying to let plugins do the dirty work.

This is still a WIP, but I wanted to see if there was any feedback thus far; I want to modularize it a bit more, and add other blocks, similar to the abilities of the My Page configuration.  Recent activities in projects that the user is a member of and the like.
