### PR TITLE
nokogiri for master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'mocha', '0.12.1'
   # capybara 2 drops ruby 1.8.7 compatibility
   gem 'capybara', '< 2.0.0'
-
+  gem 'nokogiri', '< 1.6.0'
   gem 'coveralls', :require => false
 end
 


### PR DESCRIPTION
prevent install error nokogiri on Ruby < 1.9.2

```
Gem::InstallError: nokogiri requires Ruby version >= 1.9.2.
An error occurred while installing nokogiri (1.6.0), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.6.0'` succeeds before bundling.
```
