### PR TITLE
[rebased] remove branches from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,6 @@ before_script:
   - "rake ci:travis:prepare"
   - "rm -rf tmp/test/darcs_repository" # Don't test Darcs on Travis. It breaks there :(
 script: "bundle exec rake test:$TEST_SUITE"
-branches:
-  only:
-    - unstable
-    - master
-    - stable
-    - /^stable-.*$/
-    - /^release-.*$/
 notifications:
   email: false
   irc: "irc.freenode.org#chiliproject"


### PR DESCRIPTION
It is too hard to run travis on forked branches.
It disturbs pull request process.

rebased #276.
